### PR TITLE
Add `launchdarkly` port 

### DIFF
--- a/ports/launchdarkly/fix-vcpkg-install.patch
+++ b/ports/launchdarkly/fix-vcpkg-install.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 173a383a..4e68ad6b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -115,7 +115,7 @@ option(LD_CURL_NETWORKING "Enable CURL-based networking for SSE client (alternat
+ # If using 'make' as the build system, CMake causes the 'install' target to have a dependency on 'all', meaning
+ # it will cause a full build. This disables that, allowing us to build piecemeal instead. This is useful
+ # so that we only need to build the client or server for a given release (if only the client or server were affected.)
+-set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
++# set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY false)
+ 
+ # All projects in this repo should share the same version of 3rd party depends.
+ # It's the only way to remain sane.
+@@ -127,7 +127,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ include(GNUInstallDirs)
+ set(LD_TARGETS_EXPORT_NAME ${PROJECT_NAME}Targets)
+ set(LD_CMAKE_CONFIG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+-set(LD_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}")
++set(LD_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}")
+ set(LD_CMAKE_PROJECT_CONFIG_FILE "${LD_CMAKE_CONFIG_DIR}/${PROJECT_NAME}Config.cmake")
+ set(LD_CMAKE_VERSION_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+ 

--- a/ports/launchdarkly/portfile.cmake
+++ b/ports/launchdarkly/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_from_git(
+        OUT_SOURCE_PATH CERTIFY_SOURCE_DIR
+        URL git@github.com:launchdarkly/certify
+        REF 7116dd0e609ae44d037aa562736d3d59fce1b637
+        HEAD_REF master
+)
+
+vcpkg_from_git(
+        OUT_SOURCE_PATH TIMESTAMP_SOURCE_DIR
+        URL git@github.com:chansen/c-timestamp
+        REF b205c407ae6680d23d74359ac00444b80989792f
+        HEAD_REF master
+)
+
+vcpkg_from_git(
+        OUT_SOURCE_PATH TLEXPECTED_SOURCE_DIR
+        URL git@github.com:TartanLlama/expected.git
+        REF 292eff8bd8ee230a7df1d6a1c00c4ea0eb2f0362
+        HEAD_REF master
+)
+
+vcpkg_from_git(
+        OUT_SOURCE_PATH SOURCE_PATH
+        URL git@github.com:launchdarkly/cpp-sdks.git
+        REF 3e538d47d10a13c459f9bc5e79b2492848ce985c
+        PATCHES
+        fix-vcpkg-install.patch
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS
+        -DBUILD_TESTING=OFF
+        -DVCPKG_USE_HOST_TOOLS=ON
+        -DVCPKG_HOST_TRIPLET=${HOST_TRIPLET}
+        -DFETCHCONTENT_SOURCE_DIR_CERTIFY=${CERTIFY_SOURCE_DIR}
+        -DFETCHCONTENT_SOURCE_DIR_TIMESTAMP=${TIMESTAMP_SOURCE_DIR}
+        -DFETCHCONTENT_SOURCE_DIR_TL-EXPECTED=${TLEXPECTED_SOURCE_DIR}
+        -DLD_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+
+ccp_externalize_apple_debuginfo()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ports/launchdarkly/vcpkg.json
+++ b/ports/launchdarkly/vcpkg.json
@@ -65,8 +65,7 @@
       "version>=": "1.0.1"
     },
     {
-      "name": "openssl",
-      "version>=": "1.1.1k#12"
+      "name": "openssl"
     },
     {
       "name": "pcre",

--- a/ports/launchdarkly/vcpkg.json
+++ b/ports/launchdarkly/vcpkg.json
@@ -1,0 +1,84 @@
+{
+    "name": "launchdarkly",
+    "version": "3.8.1",
+    "description": "C++ SDK for launchdarkly",
+    "dependencies": [
+        {
+            "name": "boost-asio",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-beast",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-coroutine",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-date-time",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-filesystem",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-format",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-hof",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-json",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-serialization",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-signals2",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-spirit",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-test",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-url",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "boost-uuid",
+            "version>=": "1.89.0"
+        },
+        {
+            "name": "ccp-debug-info",
+            "host": true,
+            "version>=": "1.0.1"
+        },
+        {
+            "name": "openssl",
+            "version>=": "1.1.1k#12"
+        },
+        {
+            "name": "pcre",
+            "version>=": "8.45#7"
+        },
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ]
+}

--- a/ports/launchdarkly/vcpkg.json
+++ b/ports/launchdarkly/vcpkg.json
@@ -1,84 +1,84 @@
 {
-    "name": "launchdarkly",
-    "version": "3.8.1",
-    "description": "C++ SDK for launchdarkly",
-    "dependencies": [
-        {
-            "name": "boost-asio",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-beast",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-coroutine",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-date-time",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-filesystem",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-format",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-hof",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-json",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-serialization",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-signals2",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-spirit",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-test",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-url",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "boost-uuid",
-            "version>=": "1.89.0"
-        },
-        {
-            "name": "ccp-debug-info",
-            "host": true,
-            "version>=": "1.0.1"
-        },
-        {
-            "name": "openssl",
-            "version>=": "1.1.1k#12"
-        },
-        {
-            "name": "pcre",
-            "version>=": "8.45#7"
-        },
-        {
-            "name": "vcpkg-cmake",
-            "host": true
-        },
-        {
-            "name": "vcpkg-cmake-config",
-            "host": true
-        }
-    ]
+  "name": "launchdarkly",
+  "version": "3.8.1",
+  "description": "C++ SDK for launchdarkly",
+  "dependencies": [
+    {
+      "name": "boost-asio",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-beast",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-coroutine",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-date-time",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-filesystem",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-format",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-hof",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-json",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-serialization",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-signals2",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-spirit",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-test",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-url",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "boost-uuid",
+      "version>=": "1.89.0"
+    },
+    {
+      "name": "ccp-debug-info",
+      "host": true,
+      "version>=": "1.0.1"
+    },
+    {
+      "name": "openssl",
+      "version>=": "1.1.1k#12"
+    },
+    {
+      "name": "pcre",
+      "version>=": "8.45#7"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/launchdarkly/vcpkg.json
+++ b/ports/launchdarkly/vcpkg.json
@@ -64,9 +64,7 @@
       "host": true,
       "version>=": "1.0.1"
     },
-    {
-      "name": "openssl"
-    },
+    "openssl",
     {
       "name": "pcre",
       "version>=": "8.45#7"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8,6 +8,10 @@
       "baseline": "3.1.2",
       "port-version": 0
     },
+    "launchdarkly": {
+      "baseline": "3.8.1",
+      "port-version": 0
+    },
     "python3": {
       "baseline": "3.12.3",
       "port-version": 1

--- a/versions/l-/launchdarkly.json
+++ b/versions/l-/launchdarkly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2b379e7c23b8639a1de7673b76220a449968ce2",
+      "git-tree": "c5b315e7cde434b08126761989689cfcc09bae45",
       "version": "3.8.1",
       "port-version": 0
     }

--- a/versions/l-/launchdarkly.json
+++ b/versions/l-/launchdarkly.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f2b379e7c23b8639a1de7673b76220a449968ce2",
+      "version": "3.8.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
So that the launchdarkly C++ SDK can be installed through `vcpkg`.

https://ccpgames.atlassian.net/browse/PLAT-10072