### PR TITLE
Change python3 port to enable building _testcapi extension

### DIFF
--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -138,7 +138,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
             "/p:IncludeCTypes=true"
             "/p:IncludeSSL=true"
             "/p:IncludeTkinter=false"
-            "/p:IncludeTests=false"
+            "/p:IncludeTests=true"
             "/p:ForceImportBeforeCppTargets=${SOURCE_PATH}/PCbuild/python_vcpkg.props"
         )
     else()

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3",
   "version": "3.12.9",
+  "port-version": 1,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -34,7 +34,7 @@
     },
     "python3": {
       "baseline": "3.12.9",
-      "port-version": 0
+      "port-version": 1
     }
   }
 }

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "68dd22ed7bf2f64ec4e4c65ca3a60c4b816c4d0f",
+      "version": "3.12.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "cfb769fbeb4b1497f839802dcf8bb1c53f99ebe3",
       "version": "3.12.9",
       "port-version": 0


### PR DESCRIPTION
Carbon-IO requires `_testcapi` extension, which is hard disabled in the microsoft/vcpkg python3 portfile