### PR TITLE
Add ports for Greenlet & Scheduler to registry

### DIFF
--- a/ports/carbon-scheduler/portfile.cmake
+++ b/ports/carbon-scheduler/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL git@github.com:carbonengine/scheduler.git
+  REF 818cffc3741d19a7f2b2c522ebe51e9b567ada52
+  HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH ${SOURCE_PATH}
+  OPTIONS
+    -DBUILD_TESTING=OFF
+    -DBUILD_DOCUMENTATION=OFF
+    -DCMAKE_BUILD_TYPE=${CARBON_BUILD_TYPE}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+set(BUILD_PATHS
+  "${CURRENT_PACKAGES_DIR}/bin/*.dll"
+  "${CURRENT_PACKAGES_DIR}/debug/bin/*.dll"
+  "${CURRENT_PACKAGES_DIR}/bin/*.pyd"
+  "${CURRENT_PACKAGES_DIR}/debug/bin/*.pyd"
+)
+vcpkg_copy_pdbs(
+  BUILD_PATHS ${BUILD_PATHS}
+)
+ccp_externalize_apple_debuginfo()

--- a/ports/carbon-scheduler/vcpkg.json
+++ b/ports/carbon-scheduler/vcpkg.json
@@ -1,0 +1,37 @@
+{
+  "name": "carbon-scheduler",
+  "version": "1.4.0",
+  "description": "Provides channels and a scheduler for Greenlet coroutines.",
+  "homepage": "https://github.com/carbonengine/scheduler",
+  "license": "MIT",
+  "supports": "(windows & x64) | osx",
+  "dependencies": [
+    {
+      "name": "carbon-core",
+      "version>=": "2.4.0"
+    },
+    {
+      "name": "ccp-debug-info",
+      "host": true,
+      "version>=": "1.0.1"
+    },
+    {
+      "name": "greenlet",
+      "version>=": "3.0.3"
+    },
+    {
+      "name": "python3",
+      "version>=": "3.12.9#1"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true,
+      "version>=": "2024-04-23"
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true,
+      "version>=": "2024-05-23"
+    }
+  ]
+}

--- a/ports/greenlet/CMakeLists.txt
+++ b/ports/greenlet/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.28.1)
+project(python_greenlet LANGUAGES C CXX)
+
+find_package(Python3 COMPONENTS Development REQUIRED)
+
+SET(EXTRA_LINK_LIBRARIES "")
+SET(EXTRA_COMPILE_OPTIONS "")
+
+include(cmake/CcpGlobalSettings.cmake)
+include(cmake/CcpTargetConfigurations.cmake)
+
+if(WIN32)
+    enable_language(ASM_MASM)
+
+    SET(ASM_OPTIONS "-x assembler-with-cpp")
+    SET(EXTRA_LINK_LIBRARIES switch_x64_masm)
+    SET(EXTRA_COMPILE_OPTIONS "/EHsr /GT")
+
+    add_library(switch_x64_masm OBJECT src/greenlet/platform/switch_x64_masm.asm)
+elseif(APPLE)
+    SET(EXTRA_COMPILE_OPTIONS "--std=gnu++11")
+endif()
+
+ccp_add_library(_greenlet SHARED src/greenlet/greenlet.cpp)
+
+set_target_properties(_greenlet
+        PROPERTIES
+        DEBUG_POSTFIX ""
+        INTERNAL_POSTFIX ""
+        TRINITYDEV_POSTFIX ""
+        OUTPUT_NAME _greenlet
+)
+
+target_compile_options(_greenlet PRIVATE ${EXTRA_COMPILE_OPTIONS})
+
+target_link_libraries(_greenlet
+    PRIVATE
+        Python3::Python
+        "${EXTRA_LINK_LIBRARIES}"
+)
+
+target_include_directories(_greenlet INTERFACE
+        $<INSTALL_INTERFACE:include>
+)
+
+install(FILES src/greenlet/greenlet.h DESTINATION include/)
+install(FILES src/greenlet/__init__.py DESTINATION bin/python/greenlet/)
+
+if(WIN32)
+    install(FILES $<TARGET_FILE_DIR:_greenlet>/_greenlet.pyd DESTINATION bin/)
+elseif(APPLE)
+    install(FILES $<TARGET_FILE_NAME:_greenlet>  DESTINATION bin/)
+endif()
+install(FILES greenletConfig.cmake DESTINATION ${CMAKE_INSTALL_PREFIX}/share/greenlet/)

--- a/ports/greenlet/cmake/CcpBuildConfigurations.cmake
+++ b/ports/greenlet/cmake/CcpBuildConfigurations.cmake
@@ -1,0 +1,148 @@
+# this applies to multi-configuration build system, e.g. XCode, Visual Studio, Ninja Multi-Config
+set(CMAKE_CONFIGURATION_TYPES Debug TrinityDev Internal Release)
+
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(is_multi_config)
+    set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}"
+        CACHE
+        STRING
+        "Reset the configurations to what we need"
+        FORCE
+    )
+else()
+    if (NOT CMAKE_BUILD_TYPE)
+        message(STATUS "No CMAKE_BUILD_TYPE was specified, defaulting to 'Debug'")
+        set(CMAKE_BUILD_TYPE "Debug")
+    endif()
+    # Update the documentation string of CMAKE_BUILD_TYPE for GUIs
+    set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
+        CACHE
+        STRING
+        "Choose the type of build, options are: ${CMAKE_CONFIGURATION_TYPES}."
+        FORCE
+    )
+
+    # check if a valid build type was supplied
+    if (CMAKE_BUILD_TYPE IN_LIST CMAKE_CONFIGURATION_TYPES)
+        message(STATUS "Building configuration ${CMAKE_BUILD_TYPE}")
+    else()
+        message(FATAL_ERROR "Invalid configuration ${CMAKE_BUILD_TYPE}. Available options are: ${CMAKE_CONFIGURATION_TYPES}")
+    endif()
+endif()
+
+# Create a new configuration based on an existing one
+function(create_new_build_config config prototype)
+    message(STATUS "Creating new build config '${config}' based on '${prototype}'")
+
+    string(TOUPPER ${config} CONFIG)
+    string(TOUPPER ${prototype} PROTOTYPE)
+
+    set(CMAKE_CXX_FLAGS_${CONFIG}
+        ${CMAKE_CXX_FLAGS_${PROTOTYPE}} CACHE STRING
+        "Flags used by the C++ compiler during ${config} builds."
+        FORCE)
+    set(CMAKE_C_FLAGS_${CONFIG}
+        ${CMAKE_C_FLAGS_${PROTOTYPE}} CACHE STRING
+        "Flags used by the C compiler during ${config} builds."
+        FORCE)
+    set(CMAKE_EXE_LINKER_FLAGS_${CONFIG}
+        ${CMAKE_EXE_LINKER_FLAGS_${PROTOTYPE}} CACHE STRING
+        "Flags used for linking binaries during ${config} builds."
+        FORCE)
+    set(CMAKE_SHARED_LINKER_FLAGS_${CONFIG}
+        ${CMAKE_SHARED_LINKER_FLAGS_${PROTOTYPE}} CACHE STRING
+        "Flags used by the shared libraries linker during ${config} builds."
+        FORCE)
+    mark_as_advanced(
+        CMAKE_CXX_FLAGS_${CONFIG}
+        CMAKE_C_FLAGS_${CONFIG}
+        CMAKE_EXE_LINKER_FLAGS_${CONFIG}
+        CMAKE_SHARED_LINKER_FLAGS_${CONFIG})
+endfunction()
+
+create_new_build_config(Internal Release)
+create_new_build_config(TrinityDev Internal)
+
+function(add_trinity_dev_debug_flags target)
+    if (MSVC)
+        # Set debug options
+        get_target_property(options ${target} COMPILE_OPTIONS)
+        string(REGEX REPLACE "<CONFIG:TrinityDev>,/Zi,>" "<CONFIG:TrinityDev>,/ZI,>" options "${options}")
+        string(REGEX REPLACE "<CONFIG:TrinityDev>,/O2,>" "<CONFIG:TrinityDev>,/Od,>" options "${options}")
+        set_target_properties(${target} PROPERTIES COMPILE_OPTIONS "${options}")
+        # Disable /GL and /LTCG for /ZI support
+        set_target_properties(${target} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_TRINITYDEV OFF)
+        target_link_options(${target} PRIVATE "$<IF:$<CONFIG:TrinityDev>,/LTCG:OFF,>")
+    elseif(APPLE)
+        target_compile_options(${target} PRIVATE "$<IF:$<CONFIG:TrinityDev>,-Og,>")
+    endif()
+endfunction()
+
+if (MSVC)
+    # https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-150
+    add_compile_options(/MP)
+
+    add_compile_options(/W3)
+    add_compile_options(/permissive-)
+    # Ignore missing PDB file for libraries
+    add_link_options(/IGNORE:4099)
+    # https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4098?view=msvc-150
+    add_link_options(/NODEFAULTLIB:libcmt.lib)
+
+    # https://docs.microsoft.com/en-us/cpp/text/support-for-multibyte-character-sets-mbcss?view=msvc-150
+    # We don't want this, but we currently can't use /D UNICODE since this breaks all our legacy nonsense (which we should fix)
+    # Replace with -D_UNICODE once we have fixed this
+    # https://github.com/bluescarni/mppp/issues/177
+    add_definitions(-D_SBCS)
+
+    # https://docs.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-150
+    add_compile_options($<IF:$<OR:$<CONFIG:Release>,$<CONFIG:Internal>>,/Zi,>)
+    # Generate Debug Info
+    add_link_options($<IF:$<CONFIG:Release>,/DEBUG:FULL,/DEBUG:FASTLINK>)
+
+    # Take manual control over these flags: https://gitlab.kitware.com/cmake/cmake/-/issues/19084
+    set(CMAKE_CXX_FLAGS_DEBUG "")
+    set(CMAKE_CXX_FLAGS_TRINITYDEV "")
+    set(CMAKE_C_FLAGS_TRINITYDEV "")
+    set(CMAKE_SHARED_LINKER_FLAGS_TRINITYDEV "")
+    set(CMAKE_EXE_LINKER_FLAGS_TRINITYDEV "")
+
+    add_compile_options($<IF:$<CONFIG:Debug>,/ZI,>)
+    add_compile_options($<IF:$<CONFIG:Debug>,/Od,>)
+    # Disable /GL for /ZI support
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
+
+    # Default flags which we can override
+    add_compile_options($<IF:$<CONFIG:TrinityDev>,/Zi,>)
+    add_compile_options($<IF:$<CONFIG:TrinityDev>,/O2,>)
+
+    set(MATH_OPTIMIZE_FLAG "/fp:fast")
+elseif(APPLE)
+
+    # adjust warning settings for all our projects, but do not treat them as errors just yet.
+    add_compile_options(-Wall)
+    # we want to use the two ones below once we're good with -Wall
+#    add_compile_options(-Wpedantic)
+#    add_compile_options(-Wextra)
+
+    # We're using a lot of MSVC specific pragmas in our codebase, so we silence those warnings until we got around to
+    # cleaning them up
+    add_compile_options(-Wno-unknown-pragmas)
+    # There's a surprising amount of unused functions, we need to investigate this deeper at one point
+    add_compile_options(-Wno-unused-function)
+    # Ditto, much like the functions there are also a lot of unused variables it appears
+    add_compile_options(-Wno-unused-variable)
+    # We've not been very good at keeping order
+    add_compile_options(-Wno-reorder)
+    # -Wmissing-braces should only be used by C / ObjectiveC, but for some reason it shows up for our C++ code, too.
+    add_compile_options(-Wno-missing-braces)
+
+    # Manually add debug symbols to builds
+    add_compile_options(-g)
+
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
+        set(MATH_OPTIMIZE_FLAG -ffast-math -fhonor-infinities -fhonor-nans)
+    else()
+        set(MATH_OPTIMIZE_FLAG -ffast-math -ffp-model=fast -fhonor-infinities -fhonor-nans)
+    endif()
+endif()

--- a/ports/greenlet/cmake/CcpGlobalSettings.cmake
+++ b/ports/greenlet/cmake/CcpGlobalSettings.cmake
@@ -1,0 +1,44 @@
+if(APPLE)
+    # Explicitly set the minimum macOS version we target; otherwise it defaults to whatever version
+    # we are building on, but we want to stick to our policy of supporting the last three releases.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "The minimum macOS version we target." FORCE)
+    message(STATUS "Building for minimum macOS version: ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+
+    # Explicit architecture required to support x64 builds on arm64 (Apple silicon)
+    message(STATUS "Building for ${CMAKE_OSX_ARCHITECTURES} architecture")
+endif()
+
+if(WIN32)
+    # Windows 10 is our minimum requirement, so make sure we're enforcing it.
+    add_compile_definitions(WINVER=0x0A00)
+    add_compile_definitions(_WIN32_WINNT=0x0A00)
+    add_compile_definitions(_WIN32_WINDOWS=0x0A00)
+    add_compile_definitions(NTDDI_VERSION=0x0A000000)
+    set(WIN_SDK_VERSION "10.0.17763.0")
+    set(CMAKE_SYSTEM_VERSION ${WIN_SDK_VERSION} CACHE STRING INTERNAL FORCE)
+    set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION ${WIN_SDK_VERSION} CACHE STRING INTERNAL FORCE)
+    # Avoid using MultiThreadedDebugDLL, which we don't support
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL" CACHE STRING INTERNAL FORCE)
+endif()
+
+# Require out-of-source builds
+file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
+if(EXISTS "${LOC_PATH}")
+    message(FATAL_ERROR "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_OBJCXX_VISIBILITY_PRESET hidden)
+set(CMAKE_XCODE_GENERATE_SCHEME ON)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+include(cmake/CcpBuildConfigurations.cmake)
+
+message(STATUS "CCP Platform is ${CCP_PLATFORM}")
+message(STATUS "CCP Architecture is ${CCP_ARCHITECTURE}")
+message(STATUS "CCP Toolset is ${CCP_TOOLSET}")

--- a/ports/greenlet/cmake/CcpMinimumTargetPlatform.cmake
+++ b/ports/greenlet/cmake/CcpMinimumTargetPlatform.cmake
@@ -1,0 +1,25 @@
+#[[
+Configures key CMake variables to be correct for the operating system ("platforms") we target.
+
+*Note*: On macOS, this module should be included before the first call to `project()` or `enable_language()`.
+]]
+if(APPLE)
+    # Explicitly set the minimum macOS version we target; otherwise it defaults to whatever version
+    # we are building on, but we want to stick to our policy of supporting the last three releases.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "The minimum macOS version we target." FORCE)
+    message(STATUS "Building for minimum macOS version: ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+
+    # Explicit architecture required to support x64 builds on arm64 (Apple silicon)
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Target architecture for macOS" FORCE)
+    message(STATUS "Building for ${CMAKE_OSX_ARCHITECTURES} architecture")
+endif()
+
+if(WIN32)
+    # Windows 7 is our minimum requirement, so make sure we're enforcing it.
+    add_compile_definitions(_WIN32_WINNT=0x0601)
+    set(WIN_SDK_VERSION "10.0.17763.0")
+    set(CMAKE_SYSTEM_VERSION ${WIN_SDK_VERSION} CACHE STRING INTERNAL FORCE)
+    set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION ${WIN_SDK_VERSION} CACHE STRING INTERNAL FORCE)
+    # Avoid using MultiThreadedDebugDLL, which we don't support
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL" CACHE STRING INTERNAL FORCE)
+endif()

--- a/ports/greenlet/cmake/CcpTargetConfigurations.cmake
+++ b/ports/greenlet/cmake/CcpTargetConfigurations.cmake
@@ -1,0 +1,93 @@
+macro(ensure_correct_target_type target)
+    get_target_property(target_type ${target} TYPE)
+    if(${target_type} STREQUAL "INTERFACE_LIBRARY")
+        return()
+    endif()
+    get_target_property(aliased_target ${target} ALIASED_TARGET)
+    if(aliased_target)
+        return()
+    endif()
+    get_target_property(imported_target ${target} IMPORTED)
+    if(imported_target)
+        return()
+    endif()
+endmacro()
+
+function(set_build_flavor target)
+    ensure_correct_target_type(${target})
+    set_target_properties(${target}
+        PROPERTIES
+            DEBUG_POSTFIX "_debug"
+            TRINITYDEV_POSTFIX "_trinitydev"
+            INTERNAL_POSTFIX "_internal"
+    )
+    target_compile_definitions(${target} PRIVATE CCP_BUILD_FLAVOR=$<LOWER_CASE:$<IF:$<CONFIG:Release>,,_$<CONFIG>>>)
+endfunction()
+
+function(externalize_apple_debuginfo name)
+    if (NOT APPLE)
+        return()
+    endif()
+
+    if(CMAKE_GENERATOR STREQUAL "Xcode")
+        return()
+    endif()
+
+    get_target_property(target_type ${name} TYPE)
+    if(target_type STREQUAL STATIC_LIBRARY)
+        return()
+    endif()
+
+    ensure_correct_target_type(${name})
+
+    add_custom_command(TARGET ${name} POST_BUILD
+        # Extract symbols to flat dsym file
+        VERBATIM COMMAND $<$<CONFIG:Release>:dsymutil> "$<TARGET_FILE:${name}>" -f -o $<TARGET_FILE:${name}>.sym
+        # Remove symbols from binary
+        VERBATIM COMMAND $<$<CONFIG:Release>:strip> -Sxl $<TARGET_FILE:${name}>
+    )
+endfunction()
+
+function(set_prefix_and_suffix target)
+    # Configure output directories, prefixes and suffixes
+    ensure_correct_target_type(${target})
+    set_target_properties(${target}
+        PROPERTIES
+            PREFIX ""
+    )
+    if(target_type STREQUAL SHARED_LIBRARY)
+        if(APPLE)
+            # on macOS we like to still use the .so naming convention, without a prefix
+            set_target_properties(${target}
+                PROPERTIES
+                    SUFFIX ".so"
+            )
+        elseif(WIN32)
+            # Python3 requires suffix to be pyd on Windows
+            set_target_properties(${target}
+                PROPERTIES
+                    SUFFIX ".pyd"
+            )
+        endif()
+    endif()
+endfunction()
+
+function(ccp_add_executable)
+    # Adds and configures an executable target for CCPs
+    # vendored packages. 
+    set(target ${ARGV0})
+    add_executable(${ARGN})
+    set_prefix_and_suffix(${target})
+    set_build_flavor(${target})
+    externalize_apple_debuginfo(${target})
+endfunction()
+
+function(ccp_add_library)
+    # Adds and configures a library target for CCPs
+    # vendored packages.
+    set(target ${ARGV0})
+    add_library(${ARGN})
+    set_prefix_and_suffix(${target})
+    set_build_flavor(${target})
+    externalize_apple_debuginfo(${target})
+endfunction()

--- a/ports/greenlet/greenletConfig.cmake
+++ b/ports/greenlet/greenletConfig.cmake
@@ -1,0 +1,28 @@
+add_library(Greenlet INTERFACE IMPORTED)
+
+set(Greenlet_INCLUDE_DIR "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
+set(Greenlet_VERSION "3.0.3")
+set(Greenlet_Libraries _greenlet)
+
+if(APPLE)
+    set(_SHARED_LIBRARY_SUFFIX ".so")
+else()
+    set(_SHARED_LIBRARY_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
+endif()
+
+if(APPLE)
+    set_target_properties(Greenlet PROPERTIES
+        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/_greenlet.so"
+    )
+elseif(WIN32)
+    set_target_properties(Greenlet PROPERTIES
+        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/_greenlet.pyd"
+    )
+else()
+    message(FATAL_ERROR "Greenlet not supported on platform.")
+endif()
+
+set_target_properties(Greenlet PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${Greenlet_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES ${Greenlet_Libraries}
+)

--- a/ports/greenlet/patches/delete_setup_py.patch
+++ b/ports/greenlet/patches/delete_setup_py.patch
@@ -1,0 +1,265 @@
+diff --git a/setup.py b/setup.py
+deleted file mode 100755
+index 541bb9b..0000000
+--- a/setup.py
++++ /dev/null
+@@ -1,259 +0,0 @@
+-#! /usr/bin/env python
+-# -*- coding: utf-8 -*-
+-from __future__ import print_function
+-import sys
+-import os
+-import glob
+-import platform
+-
+-# distutils is deprecated and vendored into setuptools now.
+-from setuptools import setup
+-from setuptools import Extension
+-from setuptools import find_packages
+-
+-# Extra compiler arguments passed to *all* extensions.
+-global_compile_args = []
+-
+-# Extra compiler arguments passed to C++ extensions
+-cpp_compile_args = []
+-
+-# Extra linker arguments passed to C++ extensions
+-cpp_link_args = []
+-
+-# Extra compiler arguments passed to the main extension
+-main_compile_args = []
+-
+-is_win = sys.platform.startswith("win")
+-
+-# workaround segfaults on openbsd and RHEL 3 / CentOS 3 . see
+-# https://bitbucket.org/ambroff/greenlet/issue/11/segfault-on-openbsd-i386
+-# https://github.com/python-greenlet/greenlet/issues/4
+-# https://github.com/python-greenlet/greenlet/issues/94
+-# pylint:disable=too-many-boolean-expressions
+-is_linux = sys.platform.startswith('linux') # could be linux or linux2
+-plat_platform = platform.platform()
+-plat_machine = platform.machine()
+-plat_compiler = platform.python_compiler()
+-try:
+-    # (sysname, nodename, release, version, machine)
+-    unam_machine = os.uname()[-1]
+-except AttributeError:
+-    unam_machine = ''
+-if (
+-       (sys.platform == "openbsd4" and unam_machine == "i386")
+-    or ("-with-redhat-3." in plat_platform and plat_machine == 'i686')
+-    or (sys.platform == "sunos5" and unam_machine == "sun4v") # SysV-based Solaris
+-    or ("SunOS" in plat_platform and plat_machine == "sun4v") # Old BSD-based SunOS
+-    or (is_linux and plat_machine == "ppc")
+-    # https://github.com/python-greenlet/greenlet/pull/300: When compiling for RISC-V the command
+-    # ``riscv64-linux-gnu-gcc -pthread -fno-strict-aliasing -Wdate-time \
+-    #   -D_FORTIFY_SOURCE=2 -g -ffile-prefix-map=/build/python2.7-7GU7VT/python2.7-2.7.18=. \
+-    #   -fstack-protector-strong -Wformat -Werror=format-security -fPIC \
+-    #   -I/usr/include/python2.7
+-    #   -c src/greenlet/greenlet.cpp  -o build/temp.linux-riscv64-2.7/src/greenlet/greenlet.o``
+-    #
+-    # fails with:
+-    #
+-    # src/greenlet/platform/switch_riscv_unix.h:30:1: error: s0 cannot be used in 'asm' here
+-    #
+-    # Adding the -Os flag fixes the problem.
+-    or (is_linux and plat_machine == "riscv64")
+-):
+-    global_compile_args.append("-Os")
+-
+-
+-if sys.platform == 'darwin' or 'clang' in plat_compiler:
+-    # The clang compiler doesn't use --std=c++11 by default
+-    cpp_compile_args.append("--std=gnu++11")
+-elif is_win and "MSC" in plat_compiler:
+-    # Older versions of MSVC (Python 2.7) don't handle C++ exceptions
+-    # correctly by default. While newer versions do handle exceptions
+-    # by default, they don't do it fully correctly ("By default....the
+-    # compiler generates code that only partially supports C++
+-    # exceptions."). So we need an argument on all versions.
+-
+-    #"/EH" == exception handling.
+-    #    "s" == standard C++,
+-    #    "c" == extern C functions don't throw
+-    # OR
+-    #   "a" == standard C++, and Windows SEH; anything may throw, compiler optimizations
+-    #          around try blocks are less aggressive. Because this catches SEH,
+-    #          which Windows uses internally, the MS docs say this can be a security issue.
+-    #          DO NOT USE.
+-    # /EHsc is suggested, and /EHa isn't supposed to be linked to other things not built
+-    # with it. Leaving off the "c" should just result in slower, safer code.
+-    # Other options:
+-    #    "r" == Always generate standard confirming checks for noexcept blocks, terminating
+-    #           if violated. IMPORTANT: We rely on this.
+-    # See https://docs.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170
+-    handler = "/EHsr"
+-    cpp_compile_args.append(handler)
+-    # To disable most optimizations:
+-    #cpp_compile_args.append('/Od')
+-
+-    # To enable assertions:
+-    #cpp_compile_args.append('/UNDEBUG')
+-
+-    # To enable more compile-time warnings (/Wall produces a mountain of output).
+-    #cpp_compile_args.append('/W4')
+-
+-    # To link with the debug C runtime...except we can't because we need
+-    # the Python debug lib too, and they're not around by default
+-    # cpp_compile_args.append('/MDd')
+-
+-    # Support fiber-safe thread-local storage: "the compiler mustn't
+-    # cache the address of the TLS array, or optimize it as a common
+-    # subexpression across a function call." This would probably solve
+-    # some of the issues we had with MSVC caching the thread local
+-    # variables on the stack, leading to having to split some
+-    # functions up. Revisit those.
+-    cpp_compile_args.append("/GT")
+-
+-def readfile(filename):
+-    with open(filename, 'r') as f: # pylint:disable=unspecified-encoding
+-        return f.read()
+-
+-GREENLET_SRC_DIR = 'src/greenlet/'
+-GREENLET_HEADER_DIR = GREENLET_SRC_DIR
+-GREENLET_HEADER = GREENLET_HEADER_DIR + 'greenlet.h'
+-GREENLET_TEST_DIR = 'src/greenlet/tests/'
+-# The location of the platform specific assembly files
+-# for switching.
+-GREENLET_PLATFORM_DIR = GREENLET_SRC_DIR + 'platform/'
+-
+-def _find_platform_headers():
+-    return glob.glob(GREENLET_PLATFORM_DIR + "switch_*.h")
+-
+-def _find_impl_headers():
+-    return glob.glob(GREENLET_SRC_DIR + "*.hpp") + glob.glob(GREENLET_SRC_DIR + "*.cpp")
+-
+-if hasattr(sys, "pypy_version_info"):
+-    ext_modules = []
+-    headers = []
+-else:
+-
+-    headers = [GREENLET_HEADER]
+-
+-    if is_win and '64 bit' in sys.version:
+-        # this works when building with msvc, not with 64 bit gcc
+-        # switch_<platform>_masm.obj can be created with setup_switch_<platform>_masm.cmd
+-        obj_fn = 'switch_arm64_masm.obj' if plat_machine == 'ARM64' else 'switch_x64_masm.obj'
+-        extra_objects = [os.path.join(GREENLET_PLATFORM_DIR, obj_fn)]
+-    else:
+-        extra_objects = []
+-
+-    if is_win and os.environ.get('GREENLET_STATIC_RUNTIME') in ('1', 'yes'):
+-        main_compile_args.append('/MT')
+-    elif unam_machine in ('ppc64el', 'ppc64le'):
+-        main_compile_args.append('-fno-tree-dominator-opts')
+-
+-    ext_modules = [
+-        Extension(
+-            name='greenlet._greenlet',
+-            sources=[
+-                GREENLET_SRC_DIR + 'greenlet.cpp',
+-            ],
+-            language='c++',
+-            extra_objects=extra_objects,
+-            extra_compile_args=global_compile_args + main_compile_args + cpp_compile_args,
+-            extra_link_args=cpp_link_args,
+-            depends=[
+-                GREENLET_HEADER,
+-                GREENLET_SRC_DIR + 'slp_platformselect.h',
+-            ] + _find_platform_headers() + _find_impl_headers(),
+-            define_macros=[
+-            ] + ([
+-                ('WIN32', '1'),
+-            ] if is_win else [
+-            ])
+-        ),
+-        # Test extensions.
+-        #
+-        # We used to try hard to not include these in built
+-        # distributions, because we only distributed ``greenlet.so``.
+-        # That's really not important, now we have a clean layout with
+-        # the test directory nested inside a greenlet directory. See
+-        # https://github.com/python-greenlet/greenlet/issues/184 and
+-        # 189
+-        Extension(
+-            name='greenlet.tests._test_extension',
+-            sources=[GREENLET_TEST_DIR + '_test_extension.c'],
+-            include_dirs=[GREENLET_HEADER_DIR],
+-            extra_compile_args=global_compile_args,
+-        ),
+-        Extension(
+-            name='greenlet.tests._test_extension_cpp',
+-            sources=[GREENLET_TEST_DIR + '_test_extension_cpp.cpp'],
+-            language="c++",
+-            include_dirs=[GREENLET_HEADER_DIR],
+-            extra_compile_args=global_compile_args + cpp_compile_args,
+-            extra_link_args=cpp_link_args,
+-        ),
+-    ]
+-
+-
+-def get_greenlet_version():
+-    with open('src/greenlet/__init__.py') as f: # pylint:disable=unspecified-encoding
+-        looking_for = '__version__ = \''
+-        for line in f:
+-            if line.startswith(looking_for):
+-                version = line[len(looking_for):-2]
+-                return version
+-    raise ValueError("Unable to find version")
+-
+-
+-setup(
+-    name="greenlet",
+-    version=get_greenlet_version(),
+-    description='Lightweight in-process concurrent programming',
+-    long_description=readfile("README.rst"),
+-    long_description_content_type="text/x-rst",
+-    url="https://greenlet.readthedocs.io/",
+-    keywords="greenlet coroutine concurrency threads cooperative",
+-    author="Alexey Borzenkov",
+-    author_email="snaury@gmail.com",
+-    maintainer='Jason Madden',
+-    maintainer_email='jason@seecoresoftware.com',
+-    project_urls={
+-        'Bug Tracker': 'https://github.com/python-greenlet/greenlet/issues',
+-        'Source Code': 'https://github.com/python-greenlet/greenlet/',
+-        'Documentation': 'https://greenlet.readthedocs.io/',
+-    },
+-    license="MIT License",
+-    platforms=['any'],
+-    package_dir={'': 'src'},
+-    packages=find_packages('src'),
+-    include_package_data=True,
+-    headers=headers,
+-    ext_modules=ext_modules,
+-    classifiers=[
+-        "Development Status :: 5 - Production/Stable",
+-        'Intended Audience :: Developers',
+-        'License :: OSI Approved :: MIT License',
+-        'Natural Language :: English',
+-        'Programming Language :: C',
+-        'Programming Language :: Python',
+-        'Programming Language :: Python :: 3',
+-        'Programming Language :: Python :: 3 :: Only',
+-        'Programming Language :: Python :: 3.7',
+-        'Programming Language :: Python :: 3.8',
+-        'Programming Language :: Python :: 3.9',
+-        'Programming Language :: Python :: 3.10',
+-        'Programming Language :: Python :: 3.11',
+-        'Programming Language :: Python :: 3.12',
+-        'Operating System :: OS Independent',
+-        'Topic :: Software Development :: Libraries :: Python Modules'
+-    ],
+-    extras_require={
+-        'docs': [
+-            'Sphinx',
+-            'furo',
+-        ],
+-        'test': [
+-            'objgraph',
+-            'psutil',
+-        ],
+-    },
+-    python_requires=">=3.7",
+-    zip_safe=False,
+-)

--- a/ports/greenlet/patches/fix_test_extention_importing.patch
+++ b/ports/greenlet/patches/fix_test_extention_importing.patch
@@ -1,0 +1,52 @@
+diff --git a/src/greenlet/tests/fail_cpp_exception.py b/src/greenlet/tests/fail_cpp_exception.py
+index fa4dc2e..3f657fc 100644
+--- a/src/greenlet/tests/fail_cpp_exception.py
++++ b/src/greenlet/tests/fail_cpp_exception.py
+@@ -6,7 +6,7 @@ Takes one argument, the name of the function in :mod:`_test_extension_cpp` to ca
+ """
+ import sys
+ import greenlet
+-from greenlet.tests import _test_extension_cpp
++import _test_extension_cpp
+ print('fail_cpp_exception is running')
+ 
+ def run_unhandled_exception_in_greenlet_aborts():
+diff --git a/src/greenlet/tests/test_cpp.py b/src/greenlet/tests/test_cpp.py
+index 2d0cc9c..e5e25b8 100644
+--- a/src/greenlet/tests/test_cpp.py
++++ b/src/greenlet/tests/test_cpp.py
+@@ -5,7 +5,7 @@ import subprocess
+ import unittest
+ 
+ import greenlet
+-from . import _test_extension_cpp
++import _test_extension_cpp
+ from . import TestCase
+ from . import WIN
+ 
+diff --git a/src/greenlet/tests/test_extension_interface.py b/src/greenlet/tests/test_extension_interface.py
+index 34b6656..cfc8cf1 100644
+--- a/src/greenlet/tests/test_extension_interface.py
++++ b/src/greenlet/tests/test_extension_interface.py
+@@ -4,7 +4,7 @@ from __future__ import absolute_import
+ import sys
+ 
+ import greenlet
+-from . import _test_extension
++import _test_extension
+ from . import TestCase
+ 
+ # pylint:disable=c-extension-no-member
+diff --git a/src/greenlet/tests/test_greenlet.py b/src/greenlet/tests/test_greenlet.py
+index 51849cd..8d1bee9 100644
+--- a/src/greenlet/tests/test_greenlet.py
++++ b/src/greenlet/tests/test_greenlet.py
+@@ -876,7 +876,7 @@ class TestGreenlet(TestCase):
+ 
+     def test_get_stack_with_nested_c_calls(self):
+         from functools import partial
+-        from . import _test_extension_cpp
++        import _test_extension_cpp
+ 
+         def recurse(v):
+             if v > 0:

--- a/ports/greenlet/patches/non_local_greenlet_import.patch
+++ b/ports/greenlet/patches/non_local_greenlet_import.patch
@@ -1,0 +1,59 @@
+diff --git a/src/greenlet/__init__.py b/src/greenlet/__init__.py
+index 298a19d..fe72c3f 100644
+--- a/src/greenlet/__init__.py
++++ b/src/greenlet/__init__.py
+@@ -26,26 +26,26 @@ __all__ = [
+ # Metadata
+ ###
+ __version__ = '3.0.3'
+-from ._greenlet import _C_API # pylint:disable=no-name-in-module
++from _greenlet import _C_API # pylint:disable=no-name-in-module
+ 
+ ###
+ # Exceptions
+ ###
+-from ._greenlet import GreenletExit
+-from ._greenlet import error
++from _greenlet import GreenletExit
++from _greenlet import error
+ 
+ ###
+ # greenlets
+ ###
+-from ._greenlet import getcurrent
+-from ._greenlet import greenlet
++from _greenlet import getcurrent
++from _greenlet import greenlet
+ 
+ ###
+ # tracing
+ ###
+ try:
+-    from ._greenlet import gettrace
+-    from ._greenlet import settrace
++    from _greenlet import gettrace
++    from _greenlet import settrace
+ except ImportError:
+     # Tracing wasn't supported.
+     # XXX: The option to disable it was removed in 1.0,
+@@ -58,14 +58,14 @@ except ImportError:
+ # In 1.0, USE_GC and USE_TRACING are always true, and USE_CONTEXT_VARS
+ # is the same as ``sys.version_info[:2] >= 3.7``
+ ###
+-from ._greenlet import GREENLET_USE_CONTEXT_VARS # pylint:disable=unused-import
+-from ._greenlet import GREENLET_USE_GC # pylint:disable=unused-import
+-from ._greenlet import GREENLET_USE_TRACING # pylint:disable=unused-import
++from _greenlet import GREENLET_USE_CONTEXT_VARS # pylint:disable=unused-import
++from _greenlet import GREENLET_USE_GC # pylint:disable=unused-import
++from _greenlet import GREENLET_USE_TRACING # pylint:disable=unused-import
+ 
+ # Controlling the use of the gc module. Provisional API for this greenlet
+ # implementation in 2.0.
+-from ._greenlet import CLOCKS_PER_SEC # pylint:disable=unused-import
+-from ._greenlet import enable_optional_cleanup # pylint:disable=unused-import
+-from ._greenlet import get_clocks_used_doing_optional_cleanup # pylint:disable=unused-import
++from _greenlet import CLOCKS_PER_SEC # pylint:disable=unused-import
++from _greenlet import enable_optional_cleanup # pylint:disable=unused-import
++from _greenlet import get_clocks_used_doing_optional_cleanup # pylint:disable=unused-import
+ 
+ # Other APIS in the _greenlet module are for test support.

--- a/ports/greenlet/patches/tests_remove_dir_local_imports.patch
+++ b/ports/greenlet/patches/tests_remove_dir_local_imports.patch
@@ -1,0 +1,163 @@
+diff --git a/src/greenlet/tests/__init__.py b/src/greenlet/tests/__init__.py
+index e249e35..b4d88be 100644
+--- a/src/greenlet/tests/__init__.py
++++ b/src/greenlet/tests/__init__.py
+@@ -21,8 +21,8 @@ import psutil
+ from greenlet import greenlet as RawGreenlet
+ from greenlet import getcurrent
+ 
+-from greenlet._greenlet import get_pending_cleanup_count
+-from greenlet._greenlet import get_total_main_greenlets
++from _greenlet import get_pending_cleanup_count
++from _greenlet import get_total_main_greenlets
+ 
+ from . import leakcheck
+ 
+diff --git a/src/greenlet/tests/fail_slp_switch.py b/src/greenlet/tests/fail_slp_switch.py
+index 0990526..ef905a4 100644
+--- a/src/greenlet/tests/fail_slp_switch.py
++++ b/src/greenlet/tests/fail_slp_switch.py
+@@ -6,6 +6,7 @@ fails.
+ # pragma: no cover
+ 
+ import greenlet
++import _greenlet as _greenlet
+ 
+ 
+ print('fail_slp_switch is running', flush=True)
+@@ -18,7 +19,7 @@ def func():
+     greenlet.getcurrent().parent.switch()
+     runs.append(3)
+ 
+-g = greenlet._greenlet.UnswitchableGreenlet(func)
++g = _greenlet.UnswitchableGreenlet(func)
+ g.switch()
+ assert runs == [1]
+ g.switch()
+diff --git a/src/greenlet/tests/test_greenlet.py b/src/greenlet/tests/test_greenlet.py
+index 51849cd..78e371b 100644
+--- a/src/greenlet/tests/test_greenlet.py
++++ b/src/greenlet/tests/test_greenlet.py
+@@ -13,6 +13,7 @@ import greenlet
+ from greenlet import greenlet as RawGreenlet
+ from . import TestCase
+ from .leakcheck import fails_leakcheck
++import _greenlet as _greenlet
+ 
+ 
+ # We manually manage locks in many tests
+@@ -1206,7 +1207,7 @@ class TestBrokenGreenlets(TestCase):
+             raise AssertionError("Never get here")
+ 
+ 
+-        g = greenlet._greenlet.UnswitchableGreenlet(func)
++        g = _greenlet.UnswitchableGreenlet(func)
+         g.force_switch_error = True
+ 
+         with self.assertRaisesRegex(SystemError,
+@@ -1222,7 +1223,7 @@ class TestBrokenGreenlets(TestCase):
+             greenlet.getcurrent().parent.switch()
+             runs.append(3) # pragma: no cover
+ 
+-        g = greenlet._greenlet.UnswitchableGreenlet(func)
++        g = _greenlet.UnswitchableGreenlet(func)
+         g.switch()
+         self.assertEqual(runs, [1])
+         g.switch()
+diff --git a/src/greenlet/tests/test_greenlet_trash.py b/src/greenlet/tests/test_greenlet_trash.py
+index 8d9716e..786ceac 100644
+--- a/src/greenlet/tests/test_greenlet_trash.py
++++ b/src/greenlet/tests/test_greenlet_trash.py
+@@ -39,7 +39,7 @@ class TestTrashCanReEnter(unittest.TestCase):
+ 
+     def check_it(self): # pylint:disable=too-many-statements
+         import greenlet
+-        from greenlet._greenlet import get_tstate_trash_delete_nesting # pylint:disable=no-name-in-module
++        from _greenlet import get_tstate_trash_delete_nesting # pylint:disable=no-name-in-module
+ 
+         main = greenlet.getcurrent()
+ 
+diff --git a/src/greenlet/tests/test_leaks.py b/src/greenlet/tests/test_leaks.py
+index ed1fa71..59ef052 100644
+--- a/src/greenlet/tests/test_leaks.py
++++ b/src/greenlet/tests/test_leaks.py
+@@ -13,6 +13,7 @@ import threading
+ 
+ 
+ import greenlet
++import _greenlet as _greenlet
+ from . import TestCase
+ from .leakcheck import fails_leakcheck
+ from .leakcheck import ignores_leakcheck
+@@ -117,13 +118,13 @@ class TestLeaks(TestCase):
+             self.assertIsNone(g())
+ 
+     def assertClocksUsed(self):
+-        used = greenlet._greenlet.get_clocks_used_doing_optional_cleanup()
++        used = _greenlet.get_clocks_used_doing_optional_cleanup()
+         self.assertGreaterEqual(used, 0)
+         # we don't lose the value
+-        greenlet._greenlet.enable_optional_cleanup(True)
+-        used2 = greenlet._greenlet.get_clocks_used_doing_optional_cleanup()
++        _greenlet.enable_optional_cleanup(True)
++        used2 = _greenlet.get_clocks_used_doing_optional_cleanup()
+         self.assertEqual(used, used2)
+-        self.assertGreater(greenlet._greenlet.CLOCKS_PER_SEC, 1)
++        self.assertGreater(_greenlet.CLOCKS_PER_SEC, 1)
+ 
+     def _check_issue251(self,
+                         manually_collect_background=True,
+@@ -159,7 +160,7 @@ class TestLeaks(TestCase):
+         def background_greenlet():
+             # Throw control back to the main greenlet.
+             jd = HasFinalizerTracksInstances("DELETING STACK OBJECT")
+-            greenlet._greenlet.set_thread_local(
++            _greenlet.set_thread_local(
+                 'test_leaks_key',
+                 HasFinalizerTracksInstances("DELETING THREAD STATE"))
+             # Explicitly keeping 'switch' in a local variable
+@@ -226,7 +227,7 @@ class TestLeaks(TestCase):
+         # can't reach to clean up. The C code goes through terrific
+         # lengths to clean that up.
+         if not explicit_reference_to_switch \
+-           and greenlet._greenlet.get_clocks_used_doing_optional_cleanup() is not None:
++           and _greenlet.get_clocks_used_doing_optional_cleanup() is not None:
+             # If cleanup was disabled, though, we may not find it.
+             self.assertEqual(greenlets_after, greenlets_before)
+             if manually_collect_background:
+@@ -248,18 +249,18 @@ class TestLeaks(TestCase):
+             # done by leakcheck will find it.
+             pass
+ 
+-        if greenlet._greenlet.get_clocks_used_doing_optional_cleanup() is not None:
++        if _greenlet.get_clocks_used_doing_optional_cleanup() is not None:
+             self.assertClocksUsed()
+ 
+     def test_issue251_killing_cross_thread_leaks_list(self):
+         self._check_issue251()
+ 
+     def test_issue251_with_cleanup_disabled(self):
+-        greenlet._greenlet.enable_optional_cleanup(False)
++        _greenlet.enable_optional_cleanup(False)
+         try:
+             self._check_issue251()
+         finally:
+-            greenlet._greenlet.enable_optional_cleanup(True)
++            _greenlet.enable_optional_cleanup(True)
+ 
+     @fails_leakcheck
+     def test_issue251_issue252_need_to_collect_in_background(self):
+@@ -285,11 +286,11 @@ class TestLeaks(TestCase):
+     @fails_leakcheck
+     def test_issue251_issue252_need_to_collect_in_background_cleanup_disabled(self):
+         self.expect_greenlet_leak = True
+-        greenlet._greenlet.enable_optional_cleanup(False)
++        _greenlet.enable_optional_cleanup(False)
+         try:
+             self._check_issue251(manually_collect_background=False)
+         finally:
+-            greenlet._greenlet.enable_optional_cleanup(True)
++            _greenlet.enable_optional_cleanup(True)
+ 
+     @fails_leakcheck
+     def test_issue251_issue252_explicit_reference_not_collectable(self):

--- a/ports/greenlet/portfile.cmake
+++ b/ports/greenlet/portfile.cmake
@@ -1,0 +1,37 @@
+set(PATCHES
+  patches/delete_setup_py.patch
+  patches/fix_test_extention_importing.patch
+  patches/non_local_greenlet_import.patch
+  patches/tests_remove_dir_local_imports.patch
+)
+
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL git@github.com:ccpgames/greenlet.git
+  REF ea4bc2776c75429a577e539389fee40ad9e46707 # TAG 3.0.3
+  HEAD_REF master
+  PATCHES ${PATCHES}
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/cmake DESTINATION ${SOURCE_PATH}/)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/greenletConfig.cmake DESTINATION ${SOURCE_PATH}/)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+set(BUILD_PATHS
+  "${CURRENT_PACKAGES_DIR}/bin/*.dll"
+  "${CURRENT_PACKAGES_DIR}/debug/bin/*.dll"
+  "${CURRENT_PACKAGES_DIR}/bin/*.pyd"
+  "${CURRENT_PACKAGES_DIR}/debug/bin/*.pyd"
+)
+vcpkg_copy_pdbs(
+  BUILD_PATHS ${BUILD_PATHS}
+)
+ccp_externalize_apple_debuginfo()

--- a/ports/greenlet/vcpkg.json
+++ b/ports/greenlet/vcpkg.json
@@ -2,8 +2,8 @@
   "name": "greenlet",
   "version": "3.0.3",
   "description": "Greenlets are lightweight coroutines for in-process concurrent programming.",
-  "license": "PSF-2.0",
   "homepage": "https://github.com/python-greenlet/greenlet",
+  "license": "PSF-2.0",
   "dependencies": [
     {
       "name": "ccp-debug-info",

--- a/ports/greenlet/vcpkg.json
+++ b/ports/greenlet/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "python3",
-      "version>=": "3.12.9"
+      "version>=": "3.12.9#1"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/greenlet/vcpkg.json
+++ b/ports/greenlet/vcpkg.json
@@ -2,6 +2,8 @@
   "name": "greenlet",
   "version": "3.0.3",
   "description": "Greenlets are lightweight coroutines for in-process concurrent programming.",
+  "license": "PSF-2.0",
+  "homepage": "https://github.com/python-greenlet/greenlet",
   "dependencies": [
     {
       "name": "ccp-debug-info",

--- a/ports/greenlet/vcpkg.json
+++ b/ports/greenlet/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "greenlet",
+  "version": "3.0.3",
+  "description": "Greenlets are lightweight coroutines for in-process concurrent programming.",
+  "dependencies": [
+    {
+      "name": "ccp-debug-info",
+      "host": true,
+      "version>=": "1.0.1"
+    },
+    {
+      "name": "python3",
+      "version>=": "3.12.9"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -16,6 +16,10 @@
       "baseline": "3.1.2",
       "port-version": 0
     },
+    "carbon-scheduler": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "ccp-debug-info": {
       "baseline": "1.0.1",
       "port-version": 0
@@ -23,6 +27,10 @@
     "gettext-libintl": {
       "baseline": "0.22.5",
       "port-version": 1
+    },
+    "greenlet": {
+      "baseline": "3.0.3",
+      "port-version": 0
     },
     "launchdarkly": {
       "baseline": "3.8.1",

--- a/versions/c-/carbon-scheduler.json
+++ b/versions/c-/carbon-scheduler.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0bcb6b83d3259760273ee5f9fdd37f1c3427634a",
+      "version": "1.4.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/g-/greenlet.json
+++ b/versions/g-/greenlet.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "06ff37d5f4fded178ca7a90f6252abe40f116dae",
+      "version": "3.0.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
1.4.0 of scheduler is new, and is not published in the private ccpgames registry.

greenlet 3.0.3 is the same as the latest port of greenlet in the private registry. This does not represent a problem, as scheduler is the only component that depends on greenlet.