### PR TITLE
Add our modified version of the public tracy port to the registry

### DIFF
--- a/ports/tracy/build-tools.patch
+++ b/ports/tracy/build-tools.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72901a8c..365724a8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -193,3 +193,15 @@ if(TRACY_CLIENT_PYTHON)
+ 
+     add_subdirectory(python)
+ endif()
++
++option(VCPKG_CLI_TOOLS "library" OFF)
++option(VCPKG_GUI_TOOLS "library" OFF)
++if(VCPKG_CLI_TOOLS)
++    add_subdirectory(csvexport)
++    add_subdirectory(capture)
++    add_subdirectory(import)
++    add_subdirectory(update)
++endif()
++if(VCPKG_GUI_TOOLS)
++    add_subdirectory(profiler)
++endif()
+diff --git a/cmake/server.cmake b/cmake/server.cmake
+index c12a3408..0d55cf91 100644
+--- a/cmake/server.cmake
++++ b/cmake/server.cmake
+@@ -1,3 +1,4 @@
++include_guard(GLOBAL)
+ set(TRACY_COMMON_DIR ${CMAKE_CURRENT_LIST_DIR}/../public/common)
+ 
+ set(TRACY_COMMON_SOURCES
+diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
+index 29f12cfa..40b3e078 100644
+--- a/cmake/vendor.cmake
++++ b/cmake/vendor.cmake
+@@ -1,3 +1,4 @@
++include_guard(GLOBAL)
+ # Vendor Specific CMake
+ # The Tracy project keeps most vendor source locally
+ 

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -1,0 +1,94 @@
+vcpkg_download_distfile(PATCH_MISSING_CHRONO_INCLUDE
+    URLS https://github.com/wolfpld/tracy/commit/50ff279aaddfd91dc3cdcfd5b7aec3978e63da25.diff?full_index=1
+    SHA512 f9594297ea68612b68bd631497cd312ea01b34280a0f098de0d2b99810149345251a8985a6430337d0b55d2f181ceac10d563b64cfe48f78959f79ec7a6ea3b5
+    FILENAME wolfpld-tracy-PR982.diff
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wolfpld/tracy
+    REF "v${VERSION}"
+    SHA512 d3d99284e3c3172236c3f02b3bc52df111ef650fb8609e54fb3302ece28e55a06cd16713ed532f1e1aad66678ff09639dfc7e01a1e96880fb923b267a1b1b79b
+    HEAD_REF master
+    PATCHES
+        build-tools.patch
+		"${PATCH_MISSING_CHRONO_INCLUDE}"
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        on-demand                        TRACY_ON_DEMAND
+        fibers	                         TRACY_FIBERS
+        verbose                          TRACY_VERBOSE
+        manual-lifetime                  TRACY_MANUAL_LIFETIME
+        delayed-init                     TRACY_DELAYED_INIT
+        no-callstack                     TRACY_NO_CALLSTACK
+        no-callstack-inlines             TRACY_NO_CALLSTACK_INLINES
+        only-localhost                   TRACY_ONLY_LOCALHOST
+        no-broadcast                     TRACY_NO_BROADCAST
+        only-ipv4                        TRACY_ONLY_IPV4
+        no-code-transfer                 TRACY_NO_CODE_TRANSFER
+        no-context-switch                TRACY_NO_CONTEXT_SWITCH
+        no-exit                          TRACY_NO_EXIT
+        no-sampling                      TRACY_NO_SAMPLING
+        no-verify                        TRACY_NO_VERIFY
+        no-vsync-capture                 TRACY_NO_VSYNC_CAPTURE
+        no-frame-image                   TRACY_NO_FRAME_IMAGE
+        no-system-tracing                TRACY_NO_SYSTEM_TRACING
+        patchable-nopsleds               TRACY_PATCHABLE_NOPSLEDS
+        timer-fallback                   TRACY_TIMER_FALLBACK
+        libunwind-backtrace              TRACY_LIBUNWIND_BACKTRACE
+        symbol-offline-resolve           TRACY_SYMBOL_OFFLINE_RESOLVE
+        libbacktrace-elf-dynload-support TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT
+
+    INVERTED_FEATURES
+        crash-handler TRACY_NO_CRASH_HANDLER
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS TOOLS_OPTIONS
+    FEATURES
+        cli-tools VCPKG_CLI_TOOLS
+        gui-tools VCPKG_GUI_TOOLS
+)
+
+if("cli-tools" IN_LIST FEATURES OR "gui-tools" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    list(APPEND TOOLS_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DDOWNLOAD_CAPSTONE=OFF
+        -DLEGACY=ON
+        ${FEATURE_OPTIONS}
+    OPTIONS_RELEASE
+        ${TOOLS_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        DOWNLOAD_CAPSTONE
+        LEGACY
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy)
+
+function(tracy_copy_tool tool_name tool_dir)
+    vcpkg_copy_tools(
+        TOOL_NAMES "${tool_name}"
+        SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/${tool_dir}"
+    )
+endfunction()
+
+if("cli-tools" IN_LIST FEATURES)
+    tracy_copy_tool(tracy-capture capture)
+    tracy_copy_tool(tracy-csvexport csvexport)
+    tracy_copy_tool(tracy-import-chrome import)
+    tracy_copy_tool(tracy-import-fuchsia import)
+    tracy_copy_tool(tracy-update update)
+endif()
+if("gui-tools" IN_LIST FEATURES)
+    tracy_copy_tool(tracy-profiler profiler)
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,0 +1,149 @@
+{
+  "name": "tracy",
+  "version": "0.11.1",
+  "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
+  "homepage": "https://github.com/wolfpld/tracy",
+  "license": "BSD-3-Clause",
+  "supports": "!(windows & (arm | uwp))",
+  "dependencies": [
+    {
+      "name": "pthreads",
+      "platform": "!windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "crash-handler"
+  ],
+  "features": {
+    "cli-tools": {
+      "description": "Build Tracy command-line tools: `capture`, `csvexport`, `import-chrome`, `import-fuchsia` and `update`",
+      "supports": "!(windows & x86)",
+      "dependencies": [
+        {
+          "name": "capstone",
+          "features": [
+            "arm",
+            "arm64",
+            "x86"
+          ]
+        },
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "!windows"
+        },
+        "freetype",
+        "glfw3",
+        {
+          "name": "tbb",
+          "platform": "!windows"
+        }
+      ]
+    },
+    "crash-handler": {
+      "description": "Enable crash handler"
+    },
+    "delayed-init": {
+      "description": "Enable delayed initialization of the library (init on first call)"
+    },
+    "fibers": {
+      "description": "Enable fibers support"
+    },
+    "gui-tools": {
+      "description": "Build Tracy GUI tool: `profiler` (aka `Tracy` executable)",
+      "supports": "!(windows & x86)",
+      "dependencies": [
+        {
+          "name": "capstone",
+          "features": [
+            "arm",
+            "arm64",
+            "x86"
+          ]
+        },
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "!windows"
+        },
+        "freetype",
+        "glfw3",
+        {
+          "name": "tbb",
+          "platform": "!windows"
+        }
+      ]
+    },
+    "libbacktrace-elf-dynload-support": {
+      "description": "Enable libbacktrace to support dynamically loaded elfs in symbol resolution resolution after the first symbol resolve operation"
+    },
+    "libunwind-backtrace": {
+      "description": "Use libunwind backtracing where supported"
+    },
+    "manual-lifetime": {
+      "description": "Enable the manual lifetime management of the profile"
+    },
+    "no-broadcast": {
+      "description": "Disable client discovery by broadcast to local network"
+    },
+    "no-callstack": {
+      "description": "Disable all callstack related functionality"
+    },
+    "no-callstack-inlines": {
+      "description": "Disables the inline functions in callstacks"
+    },
+    "no-code-transfer": {
+      "description": "Disable collection of source code"
+    },
+    "no-context-switch": {
+      "description": "Disable capture of context switches"
+    },
+    "no-exit": {
+      "description": "Client executable does not exit until all profile data is sent to server"
+    },
+    "no-frame-image": {
+      "description": "Disable the frame image support and its thread"
+    },
+    "no-sampling": {
+      "description": "Disable call stack sampling"
+    },
+    "no-system-tracing": {
+      "description": "Disable systrace sampling"
+    },
+    "no-verify": {
+      "description": "Disable zone validation for C API"
+    },
+    "no-vsync-capture": {
+      "description": "Disable capture of hardware Vsync events"
+    },
+    "on-demand": {
+      "description": "Enable on-demand profiling"
+    },
+    "only-ipv4": {
+      "description": "Tracy will only accept connections on IPv4 addresses (disable IPv6)"
+    },
+    "only-localhost": {
+      "description": "Only listen on the localhost interface"
+    },
+    "patchable-nopsleds": {
+      "description": "Enable nopsleds for efficient patching by system-level tools (e.g. rr)"
+    },
+    "symbol-offline-resolve": {
+      "description": "Instead of full runtime symbol resolution, only resolve the image path and offset to enable offline symbol resolution"
+    },
+    "timer-fallback": {
+      "description": "Use lower resolution timers"
+    },
+    "verbose": {
+      "description": "Enables verbose logging"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -43,6 +43,10 @@
     "python3": {
       "baseline": "3.12.9",
       "port-version": 1
+    },
+    "tracy": {
+      "baseline": "0.11.1",
+      "port-version": 0
     }
   }
 }

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "40611e2fa8291beda5b481dc5bbac61be0911bfd",
+      "version": "0.11.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Making this available as it's a core dependency of other open source components `scheduler` and `core`. Without this modified version of tracy, you are unable to build those components, even though they are opensource

There are no differences between this port and the one in our private registry