### PR TITLE
Move both craspad and zlib ports from private ccpgames registry

### DIFF
--- a/ports/crashpad/2to3_find_mac_sdk_py.patch
+++ b/ports/crashpad/2to3_find_mac_sdk_py.patch
@@ -1,0 +1,303 @@
+diff --git a/build/find_mac_sdk.py b/build/find_mac_sdk.py
+index 1c2aace..31fda2e 100755
+--- a/build/find_mac_sdk.py
++++ b/build/find_mac_sdk.py
+@@ -1,14 +1,13 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # coding: utf-8
+ 
+-# Copyright 2012 The Chromium Authors. All rights reserved.
++# Copyright 2012 The Chromium Authors
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+ from __future__ import print_function
+ 
+ import argparse
+-import distutils.version
+ import os
+ import re
+ import subprocess
+@@ -16,149 +15,157 @@ import sys
+ import textwrap
+ 
+ 
+-def _AsVersion(string):
+-  return distutils.version.StrictVersion(string)
++def _AsVersion(version_str):
++    return tuple((int(s) for s in re.findall(r'(\d+)', version_str)))
+ 
+ 
+ def _RunXCRun(args, sdk=None):
+-  xcrun_args = ['xcrun']
+-  if sdk is not None:
+-    xcrun_args.extend(['--sdk', sdk])
+-  xcrun_args.extend(args)
+-  return subprocess.check_output(xcrun_args).decode('utf-8').rstrip()
++    xcrun_args = ['xcrun']
++    if sdk is not None:
++        xcrun_args.extend(['--sdk', sdk])
++    xcrun_args.extend(args)
++    return subprocess.check_output(xcrun_args).decode('utf-8').rstrip()
+ 
+ 
+ def _SDKPath(sdk=None):
+-  return _RunXCRun(['--show-sdk-path'], sdk)
++    return _RunXCRun(['--show-sdk-path'], sdk)
+ 
+ 
+ def _SDKVersion(sdk=None):
+-  return _AsVersion(_RunXCRun(['--show-sdk-version'], sdk))
++    return _AsVersion(_RunXCRun(['--show-sdk-version'], sdk))
+ 
+ 
+ class DidNotMeetCriteria(Exception):
+-  pass
++    pass
+ 
+ 
+ def _FindPlatformSDKWithMinimumVersion(platform, minimum_sdk_version_str):
+-  minimum_sdk_version = _AsVersion(minimum_sdk_version_str)
+-
+-  # Try the SDKs that Xcode knows about.
+-  xcodebuild_showsdks_subprocess = subprocess.Popen(
+-      ['xcodebuild', '-showsdks'],
+-      stdout=subprocess.PIPE,
+-      stderr=open(os.devnull, 'w'))
+-  xcodebuild_showsdks_output = (
+-      xcodebuild_showsdks_subprocess.communicate()[0].decode('utf-8'))
+-  if xcodebuild_showsdks_subprocess.returncode == 0:
+-    # Collect strings instead of version objects to preserve the precise
+-    # format used to identify each SDK.
+-    sdk_version_strs = []
+-    for line in xcodebuild_showsdks_output.splitlines():
+-      match = re.match('[ \t].+[ \t]-sdk ' + re.escape(platform) + '(.+)$',
+-                       line)
+-      if match:
+-        sdk_version_str = match.group(1)
+-        if _AsVersion(sdk_version_str) >= minimum_sdk_version:
+-          sdk_version_strs.append(sdk_version_str)
+-
+-    if len(sdk_version_strs) == 0:
+-      raise DidNotMeetCriteria({'minimum': minimum_sdk_version_str,
+-                                'platform': platform})
+-    sdk_version_str = sorted(sdk_version_strs, key=_AsVersion)[0]
+-    sdk_path = _SDKPath(platform + sdk_version_str)
+-    sdk_version = _AsVersion(sdk_version_str)
+-  else:
+-    # Xcode may not be installed. If the command-line tools are installed, use
+-    # the system’s default SDK if it meets the requirements.
+-    sdk_path = _SDKPath()
+-    sdk_version = _SDKVersion()
+-    if sdk_version < minimum_sdk_version:
+-      raise DidNotMeetCriteria({'minimum': minimum_sdk_version_str,
+-                                'platform': platform,
+-                                'sdk_path': sdk_path,
+-                                'sdk_version': str(sdk_version)})
+-
+-  return (sdk_version, sdk_path)
++    minimum_sdk_version = _AsVersion(minimum_sdk_version_str)
++
++    # Try the SDKs that Xcode knows about.
++    xcodebuild_showsdks_subprocess = subprocess.Popen(
++        ['xcodebuild', '-showsdks'],
++        stdout=subprocess.PIPE,
++        stderr=open(os.devnull, 'w'))
++    xcodebuild_showsdks_output = (
++        xcodebuild_showsdks_subprocess.communicate()[0].decode('utf-8'))
++    if xcodebuild_showsdks_subprocess.returncode == 0:
++        # Collect strings instead of version objects to preserve the precise
++        # format used to identify each SDK.
++        sdk_version_strs = []
++        for line in xcodebuild_showsdks_output.splitlines():
++            match = re.match(
++                '[ \t].+[ \t]-sdk ' + re.escape(platform) + '(.+)$', line)
++            if match:
++                sdk_version_str = match.group(1)
++                if _AsVersion(sdk_version_str) >= minimum_sdk_version:
++                    sdk_version_strs.append(sdk_version_str)
++
++        if len(sdk_version_strs) == 0:
++            raise DidNotMeetCriteria({
++                'minimum': minimum_sdk_version_str,
++                'platform': platform
++            })
++        sdk_version_str = sorted(sdk_version_strs, key=_AsVersion)[0]
++        sdk_path = _SDKPath(platform + sdk_version_str)
++        sdk_version = _AsVersion(sdk_version_str)
++    else:
++        # Xcode may not be installed. If the command-line tools are installed,
++        # use the system’s default SDK if it meets the requirements.
++        sdk_path = _SDKPath()
++        sdk_version = _SDKVersion()
++        if sdk_version < minimum_sdk_version:
++            raise DidNotMeetCriteria({
++                'minimum': minimum_sdk_version_str,
++                'platform': platform,
++                'sdk_path': sdk_path,
++                'sdk_version': str(sdk_version)
++            })
++
++    return (sdk_version, sdk_path)
+ 
+ 
+ def main(args):
+-  parser = argparse.ArgumentParser(
+-      description='Find an appropriate platform SDK',
+-      epilog='Two lines will be written to standard output: the version of the '
+-             'selected SDK, and its path.')
+-  parser.add_argument('--developer-dir',
+-                      help='path to Xcode or Command Line Tools')
+-  parser.add_argument('--exact', help='an exact SDK version to find')
+-  parser.add_argument('--minimum', help='the minimum SDK version to find')
+-  parser.add_argument('--path', help='a known SDK path to validate')
+-  parser.add_argument('--platform',
+-                      default='macosx',
+-                      help='the platform to target')
+-  parsed = parser.parse_args(args)
+-
+-  if parsed.developer_dir is not None:
+-    os.environ['DEVELOPER_DIR'] = parsed.developer_dir
+-
+-  if (os.environ.get('DEVELOPER_DIR') is None and
+-      subprocess.call(['xcode-select', '--print-path'],
+-                      stdout=open(os.devnull, 'w'),
+-                      stderr=open(os.devnull, 'w')) != 0):
+-    # This is friendlier than letting the first invocation of xcrun or
+-    # xcodebuild show the UI prompting to install developer tools at an
+-    # inopportune time.
+-    hint = 'Install Xcode and run "sudo xcodebuild -license"'
+-    if parsed.platform == 'macosx':
+-      hint += ', or install Command Line Tools with "xcode-select --install"'
+-    hint += ('. If necessary, run "sudo xcode-select --switch" to select an '
+-             'active developer tools installation.')
+-    hint = '\n'.join(textwrap.wrap(hint, 80))
+-    print(os.path.basename(sys.argv[0]) +
+-              ': No developer tools found.\n' +
++    parser = argparse.ArgumentParser(
++        description='Find an appropriate platform SDK',
++        epilog='Two lines will be written to standard output: the version of '
++        'the selected SDK, and its path.')
++    parser.add_argument('--developer-dir',
++                        help='path to Xcode or Command Line Tools')
++    parser.add_argument('--exact', help='an exact SDK version to find')
++    parser.add_argument('--minimum', help='the minimum SDK version to find')
++    parser.add_argument('--path', help='a known SDK path to validate')
++    parser.add_argument('--platform',
++                        default='macosx',
++                        help='the platform to target')
++    parsed = parser.parse_args(args)
++
++    if parsed.developer_dir is not None:
++        os.environ['DEVELOPER_DIR'] = parsed.developer_dir
++
++    if (os.environ.get('DEVELOPER_DIR') is None and
++            subprocess.call(['xcode-select', '--print-path'],
++                            stdout=open(os.devnull, 'w'),
++                            stderr=open(os.devnull, 'w')) != 0):
++        # This is friendlier than letting the first invocation of xcrun or
++        # xcodebuild show the UI prompting to install developer tools at an
++        # inopportune time.
++        hint = 'Install Xcode and run "sudo xcodebuild -license"'
++        if parsed.platform == 'macosx':
++            hint += (
++                ', or install Command Line Tools with "xcode-select --install"')
++        hint += (
++            '. If necessary, run "sudo xcode-select --switch" to select an '
++            'active developer tools installation.')
++        hint = '\n'.join(textwrap.wrap(hint, 80))
++        print(os.path.basename(sys.argv[0]) + ': No developer tools found.\n' +
+               hint,
+-          file=sys.stderr)
+-    return 1
+-
+-  if parsed.path is not None:
+-    # _SDKVersion() doesn’t work with a relative pathname argument or one that’s
+-    # a symbolic link. Such paths are suitable for other purposes, like “clang
+-    # -isysroot”, so use an absolute non-symbolic link path for _SDKVersion(),
+-    # but preserve the user’s path in sdk_path.
+-    sdk_version = _SDKVersion(os.path.realpath(parsed.path))
+-    sdk_path = parsed.path
+-  elif parsed.exact is None and parsed.minimum is None:
+-    # Use the platform’s default SDK.
+-    sdk_version = _SDKVersion(parsed.platform)
+-    sdk_path = _SDKPath(parsed.platform)
+-  elif parsed.exact is not None:
+-    sdk_version = _SDKVersion(parsed.platform + parsed.exact)
+-    sdk_path = _SDKPath(parsed.platform + parsed.exact)
+-  else:
+-    (sdk_version,
+-     sdk_path) = _FindPlatformSDKWithMinimumVersion(parsed.platform,
+-                                                    parsed.minimum)
+-
+-  # These checks may be redundant depending on how the SDK was chosen.
+-  if ((parsed.exact is not None and sdk_version != _AsVersion(parsed.exact)) or
+-      (parsed.minimum is not None and
+-       sdk_version < _AsVersion(parsed.minimum))):
+-    raise DidNotMeetCriteria({'developer_dir': parsed.developer_dir,
+-                              'exact': parsed.exact,
+-                              'minimum': parsed.minimum,
+-                              'path': parsed.path,
+-                              'platform': parsed.platform,
+-                              'sdk_path': sdk_path,
+-                              'sdk_version': str(sdk_version)})
+-
+-  # Nobody wants trailing slashes. This is true even if “/” is the SDK: it’s
+-  # better to return an empty string, which will be interpreted as “no sysroot.”
+-  sdk_path = sdk_path.rstrip(os.path.sep)
+-
+-  print(sdk_version)
+-  print(sdk_path)
+-
+-  return 0
++              file=sys.stderr)
++        return 1
++
++    if parsed.path is not None:
++        # _SDKVersion() doesn’t work with a relative pathname argument or one
++        # that’s a symbolic link. Such paths are suitable for other purposes,
++        # like “clang -isysroot”, so use an absolute non-symbolic link path for
++        # _SDKVersion(), but preserve the user’s path in sdk_path.
++        sdk_version = _SDKVersion(os.path.realpath(parsed.path))
++        sdk_path = parsed.path
++    elif parsed.exact is None and parsed.minimum is None:
++        # Use the platform’s default SDK.
++        sdk_version = _SDKVersion(parsed.platform)
++        sdk_path = _SDKPath(parsed.platform)
++    elif parsed.exact is not None:
++        sdk_version = _SDKVersion(parsed.platform + parsed.exact)
++        sdk_path = _SDKPath(parsed.platform + parsed.exact)
++    else:
++        (sdk_version,
++         sdk_path) = _FindPlatformSDKWithMinimumVersion(parsed.platform,
++                                                        parsed.minimum)
++
++    # These checks may be redundant depending on how the SDK was chosen.
++    if ((parsed.exact is not None and sdk_version != _AsVersion(parsed.exact))
++            or (parsed.minimum is not None and
++                sdk_version < _AsVersion(parsed.minimum))):
++        raise DidNotMeetCriteria({
++            'developer_dir': parsed.developer_dir,
++            'exact': parsed.exact,
++            'minimum': parsed.minimum,
++            'path': parsed.path,
++            'platform': parsed.platform,
++            'sdk_path': sdk_path,
++            'sdk_version': str(sdk_version)
++        })
++
++    # Nobody wants trailing slashes. This is true even if “/” is the SDK: it’s
++    # better to return an empty string, which will be interpreted as “no
++    # sysroot.”
++    sdk_path = sdk_path.rstrip(os.path.sep)
++
++    print(sdk_version)
++    print(sdk_path)
++
++    return 0
+ 
+ 
+ if __name__ == '__main__':
+-  sys.exit(main(sys.argv[1:]))
++    sys.exit(main(sys.argv[1:]))

--- a/ports/crashpad/2to3_win_helper_py.patch
+++ b/ports/crashpad/2to3_win_helper_py.patch
@@ -1,0 +1,448 @@
+diff --git a/build/win_helper.py b/build/win_helper.py
+index a5e1fdd..8f7b891 100644
+--- a/build/win_helper.py
++++ b/build/win_helper.py
+@@ -1,10 +1,8 @@
+-#!/usr/bin/env python
+-
+-# Copyright 2017 The Chromium Authors. All rights reserved.
++# Copyright 2017 The Chromium Authors
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import _winreg
++import winreg
+ import os
+ import re
+ import subprocess
+@@ -12,209 +10,247 @@ import sys
+ 
+ 
+ def _RegistryGetValue(key, value):
+-  """Use the _winreg module to obtain the value of a registry key.
+-
+-  Args:
+-    key: The registry key.
+-    value: The particular registry value to read.
+-  Return:
+-    contents of the registry key's value, or None on failure.
+-  """
+-  try:
+-    root, subkey = key.split('\\', 1)
+-    assert root == 'HKLM'  # Only need HKLM for now.
+-    with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, subkey) as hkey:
+-      return _winreg.QueryValueEx(hkey, value)[0]
+-  except WindowsError:
+-    return None
++    """Use the winreg module to obtain the value of a registry key.
++
++    Args:
++        key: The registry key.
++        value: The particular registry value to read.
++    Return:
++        contents of the registry key's value, or None on failure.
++    """
++    try:
++        root, subkey = key.split('\\', 1)
++        assert root == 'HKLM'  # Only need HKLM for now.
++        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, subkey) as hkey:
++            return winreg.QueryValueEx(hkey, value)[0]
++    except WindowsError:
++        return None
+ 
+ 
+ def _ExtractImportantEnvironment(output_of_set):
+-  """Extracts environment variables required for the toolchain to run from
+-  a textual dump output by the cmd.exe 'set' command."""
+-  envvars_to_save = (
+-      'include',
+-      'lib',
+-      'libpath',
+-      'path',
+-      'pathext',
+-      'systemroot',
+-      'temp',
+-      'tmp',
+-      )
+-  env = {}
+-  for line in output_of_set.splitlines():
+-    for envvar in envvars_to_save:
+-      if re.match(envvar + '=', line.lower()):
+-        var, setting = line.split('=', 1)
+-        env[var.upper()] = setting
+-        break
+-  for required in ('SYSTEMROOT', 'TEMP', 'TMP'):
+-    if required not in env:
+-      raise Exception('Environment variable "%s" '
+-                      'required to be set to valid path' % required)
+-  return env
++    """Extracts environment variables required for the toolchain to run from
++    a textual dump output by the cmd.exe 'set' command."""
++    envvars_to_save = (
++        'include',
++        'lib',
++        'libpath',
++        'path',
++        'pathext',
++        'systemroot',
++        'temp',
++        'tmp',
++    )
++    env = {}
++    for line in output_of_set.splitlines():
++        line = line.decode("utf-8")
++        for envvar in envvars_to_save:
++            if re.match(envvar + '=', line.lower()):
++                var, setting = line.split('=', 1)
++                env[var.upper()] = setting
++                break
++    for required in ('SYSTEMROOT', 'TEMP', 'TMP'):
++        if required not in env:
++            raise Exception('Environment variable "%s" '
++                            'required to be set to valid path' % required)
++    return env
+ 
+ 
+ def _FormatAsEnvironmentBlock(envvar_dict):
+-  """Format as an 'environment block' directly suitable for CreateProcess.
+-  Briefly this is a list of key=value\0, terminated by an additional \0. See
+-  CreateProcess() documentation for more details."""
+-  block = ''
+-  nul = '\0'
+-  for key, value in envvar_dict.iteritems():
+-    block += key + '=' + value + nul
+-  block += nul
+-  return block
++    """Format as an 'environment block' directly suitable for CreateProcess.
++    Briefly this is a list of key=value\0, terminated by an additional \0. See
++    CreateProcess() documentation for more details."""
++    block = ''
++    nul = '\0'
++    for key, value in envvar_dict.items():
++        block += key + '=' + value + nul
++    block += nul
++    return block
+ 
+ 
+ def _GenerateEnvironmentFiles(install_dir, out_dir, script_path):
+-  """It's not sufficient to have the absolute path to the compiler, linker, etc.
+-  on Windows, as those tools rely on .dlls being in the PATH. We also need to
+-  support both x86 and x64 compilers. Different architectures require a
+-  different compiler binary, and different supporting environment variables
+-  (INCLUDE, LIB, LIBPATH). So, we extract the environment here, wrap all
+-  invocations of compiler tools (cl, link, lib, rc, midl, etc.) to set up the
+-  environment, and then do not prefix the compiler with an absolute path,
+-  instead preferring something like "cl.exe" in the rule which will then run
+-  whichever the environment setup has put in the path."""
+-  archs = ('x86', 'amd64', 'arm64')
+-  result = []
+-  for arch in archs:
+-    # Extract environment variables for subprocesses.
+-    args = [os.path.join(install_dir, script_path)]
+-    script_arch_name = arch
+-    if script_path.endswith('SetEnv.cmd') and arch == 'amd64':
+-      script_arch_name = '/x64'
+-    if arch == 'arm64':
+-      script_arch_name = 'x86_arm64'
+-    args.extend((script_arch_name, '&&', 'set'))
+-    popen = subprocess.Popen(
+-        args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+-    variables, _ = popen.communicate()
+-    if popen.returncode != 0:
+-      raise Exception('"%s" failed with error %d' % (args, popen.returncode))
+-    env = _ExtractImportantEnvironment(variables)
+-
+-    env_block = _FormatAsEnvironmentBlock(env)
+-    basename = 'environment.' + arch
+-    with open(os.path.join(out_dir, basename), 'wb') as f:
+-      f.write(env_block)
+-    result.append(basename)
+-  return result
++    """It's not sufficient to have the absolute path to the compiler, linker,
++    etc. on Windows, as those tools rely on .dlls being in the PATH. We also
++    need to support both x86 and x64 compilers. Different architectures require
++    a different compiler binary, and different supporting environment variables
++    (INCLUDE, LIB, LIBPATH). So, we extract the environment here, wrap all
++    invocations of compiler tools (cl, link, lib, rc, midl, etc.) to set up the
++    environment, and then do not prefix the compiler with an absolute path,
++    instead preferring something like "cl.exe" in the rule which will then run
++    whichever the environment setup has put in the path."""
++    archs = ('x86', 'amd64', 'arm64')
++    result = []
++    for arch in archs:
++        # Extract environment variables for subprocesses.
++        args = [os.path.join(install_dir, script_path)]
++        script_arch_name = arch
++        if script_path.endswith('SetEnv.cmd') and arch == 'amd64':
++            script_arch_name = '/x64'
++        if arch == 'arm64':
++            script_arch_name = 'x86_arm64'
++        args.extend((script_arch_name, '&&', 'set'))
++        popen = subprocess.Popen(args,
++                                 shell=True,
++                                 stdout=subprocess.PIPE,
++                                 stderr=subprocess.STDOUT)
++        variables, _ = popen.communicate()
++        if popen.returncode != 0:
++            raise Exception('"%s" failed with error %d' %
++                            (args, popen.returncode))
++        env = _ExtractImportantEnvironment(variables)
++
++        env_block = _FormatAsEnvironmentBlock(env)
++        basename = 'environment.' + arch
++        with open(os.path.join(out_dir, basename), 'wb') as f:
++            f.write(env_block.encode())
++        result.append(basename)
++    return result
+ 
+ 
+ def _GetEnvAsDict(arch):
+-  """Gets the saved environment from a file for a given architecture."""
+-  # The environment is saved as an "environment block" (see CreateProcess()
+-  # for details, which is the format required for ninja). We convert to a dict
+-  # here. Drop last 2 NULs, one for list terminator, one for trailing vs.
+-  # separator.
+-  pairs = open(arch).read()[:-2].split('\0')
+-  kvs = [item.split('=', 1) for item in pairs]
+-  return dict(kvs)
++    """Gets the saved environment from a file for a given architecture."""
++    # The environment is saved as an "environment block" (see CreateProcess()
++    # for details, which is the format required for ninja). We convert to a dict
++    # here. Drop last 2 NULs, one for list terminator, one for trailing vs.
++    # separator.
++    pairs = open(arch).read()[:-2].split('\0')
++    kvs = [item.split('=', 1) for item in pairs]
++    return dict(kvs)
+ 
+ 
+-class WinTool(object):
+-  def Dispatch(self, args):
+-    """Dispatches a string command to a method."""
+-    if len(args) < 1:
+-      raise Exception("Not enough arguments")
+-
+-    method = "Exec%s" % self._CommandifyName(args[0])
+-    return getattr(self, method)(*args[1:])
+-
+-  def _CommandifyName(self, name_string):
+-    """Transforms a tool name like recursive-mirror to RecursiveMirror."""
+-    return name_string.title().replace('-', '')
+-
+-  def ExecLinkWrapper(self, arch, *args):
+-    """Filter diagnostic output from link that looks like:
+-    '   Creating library ui.dll.lib and object ui.dll.exp'
+-    This happens when there are exports from the dll or exe.
+-    """
+-    env = _GetEnvAsDict(arch)
++def _SlashSlashes(args):
++    """Returns args as list, with backslashes instead of slashes in args[0]."""
+     args = list(args)  # *args is a tuple by default, which is read-only.
+     args[0] = args[0].replace('/', '\\')
+-    link = subprocess.Popen(args, env=env, shell=True, stdout=subprocess.PIPE)
+-    out, _ = link.communicate()
+-    for line in out.splitlines():
+-      if (not line.startswith('   Creating library ') and
+-          not line.startswith('Generating code') and
+-          not line.startswith('Finished generating code')):
+-        print line
+-    return link.returncode
+-
+-  def ExecAsmWrapper(self, arch, *args):
+-    """Filter logo banner from invocations of asm.exe."""
+-    env = _GetEnvAsDict(arch)
+-    popen = subprocess.Popen(args, env=env, shell=True,
+-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+-    out, _ = popen.communicate()
+-    for line in out.splitlines():
+-      if (not line.startswith('Copyright (C) Microsoft Corporation') and
+-          not line.startswith('Microsoft (R) Macro Assembler') and
+-          not line.startswith(' Assembling: ') and
+-          line):
+-        print line
+-    return popen.returncode
+-
+-  def ExecGetVisualStudioData(self, outdir, toolchain_path):
+-    setenv_path = os.path.join('win_sdk', 'bin', 'SetEnv.cmd')
+-
+-    def explicit():
+-      if os.path.exists(os.path.join(toolchain_path, setenv_path)):
+-        return toolchain_path, setenv_path
+-
+-    def env():
+-      from_env = os.environ.get('VSINSTALLDIR')
+-      if from_env and os.path.exists(os.path.join(from_env, setenv_path)):
+-        return from_env, setenv_path
+-
+-    def autodetect():
+-      # Try vswhere, which will find VS2017.2+. Note that earlier VS2017s will
+-      # not be found.
+-      vswhere_path = os.path.join(os.environ.get('ProgramFiles(x86)'),
+-          'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+-      if os.path.exists(vswhere_path):
+-        installation_path = subprocess.check_output(
+-            [vswhere_path, '-latest', '-property', 'installationPath']).strip()
+-        if installation_path:
+-          return (installation_path,
+-                  os.path.join('VC', 'Auxiliary', 'Build', 'vcvarsall.bat'))
+-
+-      # Otherwise, try VS2015.
+-      version = '14.0'
+-      keys = [r'HKLM\Software\Microsoft\VisualStudio\%s' % version,
+-              r'HKLM\Software\Wow6432Node\Microsoft\VisualStudio\%s' % version]
+-      for key in keys:
+-        path = _RegistryGetValue(key, 'InstallDir')
+-        if not path:
+-          continue
+-        return (os.path.normpath(os.path.join(path, os.pardir, os.pardir)),
+-                os.path.join('VC', 'vcvarsall.bat'))
+-
+-    def fail(): raise Exception('Visual Studio installation dir not found')
+-
+-    # Use an explicitly specified toolchain path, if provided and found.
+-    # Otherwise, try using a standard environment variable. Finally, try
+-    # autodetecting using vswhere.
+-    install_dir, script_path = (explicit() or env() or autodetect() or fail())
+-
+-    x86_file, x64_file, arm64_file = _GenerateEnvironmentFiles(
+-        install_dir, outdir, script_path)
+-    result = '''install_dir = "%s"
++    return args
++
++
++class WinTool(object):
++
++    def Dispatch(self, args):
++        """Dispatches a string command to a method."""
++        if len(args) < 1:
++            raise Exception("Not enough arguments")
++
++        method = "Exec%s" % self._CommandifyName(args[0])
++        return getattr(self, method)(*args[1:])
++
++    def _CommandifyName(self, name_string):
++        """Transforms a tool name like recursive-mirror to RecursiveMirror."""
++        return name_string.title().replace('-', '')
++
++    def ExecLinkWrapper(self, arch, *args):
++        """Filter diagnostic output from link that looks like:
++        '   Creating library ui.dll.lib and object ui.dll.exp'
++        This happens when there are exports from the dll or exe.
++        """
++        env = _GetEnvAsDict(arch)
++        args = _SlashSlashes(args)
++        link = subprocess.Popen(args,
++                                env=env,
++                                shell=True,
++                                stdout=subprocess.PIPE)
++        out, _ = link.communicate()
++        for line in out.splitlines():
++            line = line.decode("utf-8")
++            if (not line.startswith('   Creating library ') and
++                    not line.startswith('Generating code') and
++                    not line.startswith('Finished generating code')):
++                print(line)
++        return link.returncode
++
++    def ExecAsmWrapper(self, arch, *args):
++        """Filter logo banner from invocations of asm.exe."""
++        env = _GetEnvAsDict(arch)
++        args = _SlashSlashes(args)
++        popen = subprocess.Popen(args,
++                                 env=env,
++                                 shell=True,
++                                 stdout=subprocess.PIPE,
++                                 stderr=subprocess.STDOUT)
++        out, _ = popen.communicate()
++        for line in out.splitlines():
++            line = line.decode("utf-8")
++            if (not line.startswith('Copyright (C) Microsoft Corporation') and
++                    not line.startswith('Microsoft (R) Macro Assembler') and
++                    not line.startswith(' Assembling: ') and line):
++                print(line)
++        return popen.returncode
++
++    def ExecGetVisualStudioData(self, outdir, toolchain_path):
++        setenv_paths = [
++            # cipd packaged SDKs from 10.0.19041.0 onwards.
++            os.path.join('Windows Kits', '10', 'bin', 'SetEnv.cmd'),
++            # cipd packaged SDKs prior to 10.0.19041.0.
++            os.path.join('win_sdk', 'bin', 'SetEnv.cmd'),
++        ]
++
++        def explicit():
++            for setenv_path in setenv_paths:
++                if os.path.exists(os.path.join(toolchain_path, setenv_path)):
++                    return toolchain_path, setenv_path
++
++        def env():
++            from_env = os.environ.get('VSINSTALLDIR')
++            for setenv_path in setenv_paths:
++                if from_env and os.path.exists(
++                        os.path.join(from_env, setenv_path)):
++                    return from_env, setenv_path
++
++        def autodetect():
++            # Try vswhere, which will find VS2017.2+. Note that earlier VS2017s
++            # will not be found.
++            vswhere_path = os.path.join(os.environ.get('ProgramFiles(x86)'),
++                                        'Microsoft Visual Studio', 'Installer',
++                                        'vswhere.exe')
++            if os.path.exists(vswhere_path):
++                installation_path = subprocess.check_output([
++                    vswhere_path, '-products', '*', '-latest', '-property',
++                    'installationPath'
++                ]).strip()
++                if installation_path:
++                    return (installation_path.decode("utf-8"),
++                            os.path.join('VC', 'Auxiliary', 'Build',
++                                         'vcvarsall.bat'))
++
++            # Otherwise, try VS2015.
++            version = '14.0'
++            keys = [
++                r'HKLM\Software\Microsoft\VisualStudio\%s' % version,
++                r'HKLM\Software\Wow6432Node\Microsoft\VisualStudio\%s' % version
++            ]
++            for key in keys:
++                path = _RegistryGetValue(key, 'InstallDir')
++                if not path:
++                    continue
++                return (os.path.normpath(
++                    os.path.join(path, os.pardir, os.pardir)),
++                        os.path.join('VC', 'vcvarsall.bat'))
++
++        def fail():
++            raise Exception('Visual Studio installation dir not found')
++
++        # Use an explicitly specified toolchain path, if provided and found.
++        # Otherwise, try using a standard environment variable. Finally, try
++        # autodetecting using vswhere.
++        install_dir, script_path = (explicit() or env() or autodetect() or
++                                    fail())
++
++        x86_file, x64_file, arm64_file = _GenerateEnvironmentFiles(
++            install_dir, outdir, script_path)
++        # gn is unhappy with trailing backslashes.
++        install_dir = install_dir.rstrip('\\')
++        result = '''install_dir = "%s"
+ x86_environment_file = "%s"
+ x64_environment_file = "%s"
+ arm64_environment_file = "%s"''' % (install_dir, x86_file, x64_file, arm64_file)
+-    print result
+-    return 0
++        print(result)
++        return 0
+ 
+-  def ExecStamp(self, path):
+-    """Simple stamp command."""
+-    open(path, 'w').close()
+-    return 0
++    def ExecStamp(self, path):
++        """Simple stamp command."""
++        open(path, 'w').close()
++        return 0
+ 
+ 
+ if __name__ == '__main__':
+-  sys.exit(WinTool().Dispatch(sys.argv[1:]))
++    sys.exit(WinTool().Dispatch(sys.argv[1:]))

--- a/ports/crashpad/crashpadConfig.cmake.in
+++ b/ports/crashpad/crashpadConfig.cmake.in
@@ -1,0 +1,35 @@
+# Compute the installation prefix relative to this file.
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+add_library(crashpad INTERFACE)
+add_library(crashpad::crashpad ALIAS crashpad)
+
+add_executable(crashpad::handler IMPORTED GLOBAL)
+
+set(CRASHPAD_LIBRARIES client util base)
+
+if(WIN32)
+  set_target_properties(crashpad::handler PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/tools/crashpad_handler.exe)
+	target_compile_definitions(crashpad INTERFACE NOMINMAX)
+elseif(APPLE)
+  set_target_properties(crashpad::crashpad_handler PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/tools/crashpad_handler)
+	list(APPEND CRASHPAD_LIBRARIES ApplicationServices
+        CoreFoundation Foundation IOKit Security bsm mig_output)
+endif()
+
+foreach(LIB_NAME ${CRASHPAD_LIBRARIES})
+  find_library(_LIB ${LIB_NAME})
+  target_link_libraries(crashpad INTERFACE ${_LIB})
+  unset(_LIB CACHE)
+endforeach()
+
+find_package(ZLIB REQUIRED)
+target_link_libraries(crashpad INTERFACE ZLIB::ZLIB)
+
+target_include_directories(crashpad 
+        INTERFACE ${_IMPORT_PREFIX}/include/crashpad)

--- a/ports/crashpad/dot_gn_python_exe.patch
+++ b/ports/crashpad/dot_gn_python_exe.patch
@@ -1,0 +1,9 @@
+diff --git a/.gn b/.gn
+index d447a553..e4dc49c3 100644
+--- a/.gn
++++ b/.gn
+@@ -13,3 +13,4 @@
+ # limitations under the License.
+ 
+ buildconfig = "//build/BUILDCONFIG.gn"
++script_executable = "python3"

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -1,0 +1,163 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+# Original version of crashpad that this adapted portfile was checking out 9a31d3f8e9815774026a753a1ff6155347cd549f
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://chromium.googlesource.com/crashpad/crashpad
+    REF db9863a2177a2b3d329bc31fb307302b80b00dd0
+    PATCHES
+        dot_gn_python_exe.patch
+)
+
+
+
+vcpkg_find_acquire_program(PYTHON3)
+vcpkg_replace_string("${SOURCE_PATH}/.gn" "script_executable = \"python3\"" "script_executable = \"${PYTHON3}\"")
+
+function(checkout_in_path PATH URL REF)
+    set(options "")
+    set(single_value_keywords "")
+    set(multi_value_keywords "PATCHES")
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+            "${options}" "${single_value_keywords}" "${multi_value_keywords}"
+    )
+
+    if(EXISTS "${PATH}")
+        return()
+    endif()
+    
+    vcpkg_from_git(
+        OUT_SOURCE_PATH DEP_SOURCE_PATH
+        URL "${URL}"
+        REF "${REF}"
+        PATCHES ${arg_PATCHES}
+    )
+    file(RENAME "${DEP_SOURCE_PATH}" "${PATH}")
+    file(REMOVE_RECURSE "${DEP_SOURCE_PATH}")
+endfunction()
+
+# Original version of mini_chromium that this adapted portfile was checkingt out c426ff98e1d9e9d59777fe8b883a5c0ceeca9ca3
+checkout_in_path(
+    "${SOURCE_PATH}/third_party/mini_chromium/mini_chromium"
+    "https://chromium.googlesource.com/chromium/mini_chromium"
+    "329ca82f73a592d832e79334bed842fba85b9fdd"
+    PATCHES 
+        2to3_win_helper_py.patch
+        2to3_find_mac_sdk_py.patch
+)
+
+function(replace_gn_dependency INPUT_FILE OUTPUT_FILE LIBRARY_NAMES)
+    unset(_LIBRARY_DEB CACHE)
+    find_library(_LIBRARY_DEB NAMES ${LIBRARY_NAMES}
+        PATHS "${CURRENT_INSTALLED_DIR}/debug/lib"
+        NO_DEFAULT_PATH)
+
+    if(_LIBRARY_DEB MATCHES "-NOTFOUND")
+        message(WARNING "Could not find debug library with names: ${LIBRARY_NAMES}")
+    endif()
+
+    unset(_LIBRARY_REL CACHE)
+    find_library(_LIBRARY_REL NAMES ${LIBRARY_NAMES}
+        PATHS "${CURRENT_INSTALLED_DIR}/lib"
+        NO_DEFAULT_PATH)
+
+    if(_LIBRARY_REL MATCHES "-NOTFOUND")
+        message(WARNING "Could not find library with names: ${LIBRARY_NAMES}")
+    endif()
+
+    set(_INCLUDE_DIR "${CURRENT_INSTALLED_DIR}/include")
+
+    file(REMOVE "${OUTPUT_FILE}")
+    configure_file("${INPUT_FILE}" "${OUTPUT_FILE}" @ONLY)
+endfunction()
+
+replace_gn_dependency(
+    "${CMAKE_CURRENT_LIST_DIR}/zlib.gn"
+    "${SOURCE_PATH}/third_party/zlib/BUILD.gn"
+    "z;zlib;zlibd"
+)
+
+set(OPTIONS_DBG "is_debug=true")
+set(OPTIONS_REL "")
+
+if(CMAKE_HOST_WIN32)
+    # Load toolchains
+    if(NOT VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
+        set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${SCRIPTS}/toolchains/windows.cmake")
+    endif()
+    include("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
+
+    foreach(_VAR CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS
+        CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE)
+        string(STRIP "${${_VAR}}" ${_VAR})
+    endforeach()
+
+    set(OPTIONS_DBG "${OPTIONS_DBG} \
+        extra_cflags_c=\"${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}\" \
+        extra_cflags_cc=\"${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}\"")
+
+    set(OPTIONS_REL "${OPTIONS_REL} \
+        extra_cflags_c=\"${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}\" \
+        extra_cflags_cc=\"${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}\"")
+
+    set(DISABLE_WHOLE_PROGRAM_OPTIMIZATION "\
+        extra_cflags=\"/GL-\" \
+        extra_ldflags=\"/LTCG:OFF\" \
+        extra_arflags=\"/LTCG:OFF\"")
+
+    set(OPTIONS_DBG "${OPTIONS_DBG} ${DISABLE_WHOLE_PROGRAM_OPTIMIZATION}")
+    set(OPTIONS_REL "${OPTIONS_REL} ${DISABLE_WHOLE_PROGRAM_OPTIMIZATION}")
+endif()
+
+if (VCPKG_TARGET_IS_OSX)
+    # check whether we want to build a universal binary
+    list(FIND VCPKG_TARGET_ARCHITECTURE arm64 FOUND_ARM64)
+    list(FIND VCPKG_TARGET_ARCHITECTURE x86_64 FOUND_X64)
+
+    if (FOUND_X64 GREATER -1 AND FOUND_ARM64 GREATER -1)
+        set(OPTIONS_DBG "${OPTIONS_DBG} target_cpu=\"mac_universal\"")
+        set(OPTIONS_REL "${OPTIONS_REL} target_cpu=\"mac_universal\"")
+    endif()
+endif()
+
+vcpkg_gn_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS_DEBUG "${OPTIONS_DBG}"
+    OPTIONS_RELEASE "${OPTIONS_REL}"
+)
+
+set(CRASHPAD_TARGETS client util third_party/mini_chromium/mini_chromium/base handler:crashpad_handler)
+
+if (VCPKG_TARGET_IS_OSX)
+    list(APPEND CRASHPAD_TARGETS util:mig_output)
+endif()
+
+vcpkg_gn_install(
+    SOURCE_PATH "${SOURCE_PATH}"
+    TARGETS ${CRASHPAD_TARGETS}
+)
+
+message(STATUS "Installing headers...")
+set(PACKAGES_INCLUDE_DIR "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+function(install_headers DIR)
+    file(COPY "${DIR}" DESTINATION "${PACKAGES_INCLUDE_DIR}" FILES_MATCHING PATTERN "*.h")
+endfunction()
+install_headers("${SOURCE_PATH}/client")
+install_headers("${SOURCE_PATH}/util")
+install_headers("${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/base")
+install_headers("${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/build")
+
+file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/gen/build/chromeos_buildflags.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}/build")
+
+# remove empty directories
+file(REMOVE_RECURSE 
+    "${PACKAGES_INCLUDE_DIR}/util/net/testdata" 
+    "${PACKAGES_INCLUDE_DIR}/build/ios")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/crashpadConfig.cmake.in"
+        "${CURRENT_PACKAGES_DIR}/share/${PORT}/crashpadConfig.cmake" @ONLY)
+
+vcpkg_copy_pdbs()
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    RENAME copyright)

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "crashpad",
+  "version": "2021-04-14",
+  "description": [
+    "Crashpad is a crash-reporting system.",
+    "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."
+  ],
+  "dependencies": [
+    "vcpkg-gn",
+    "zlib"
+  ]
+}

--- a/ports/crashpad/zlib.gn
+++ b/ports/crashpad/zlib.gn
@@ -1,0 +1,15 @@
+import("../../build/crashpad_buildconfig.gni")
+
+config("zlib_config") {
+  defines = [ "CRASHPAD_ZLIB_SOURCE_EXTERNAL" ]
+  include_dirs = [ "@_INCLUDE_DIR@" ]
+}
+
+source_set("zlib") {
+  public_configs = [ ":zlib_config" ]
+  if(is_debug) {
+    libs = [ "@_LIBRARY_DEB@" ]  
+  } else {
+    libs = [ "@_LIBRARY_REL@" ]
+  }
+}

--- a/ports/zlib/outputname.patch
+++ b/ports/zlib/outputname.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 38885089..a30e6053 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1372,13 +1372,13 @@ if(WIN32)
+     # Static library
+     if(NOT DEFINED BUILD_SHARED_LIBS)
+         if(MSVC)
+-            set_target_properties(zlibstatic PROPERTIES OUTPUT_NAME zlibstatic${SUFFIX})
++            set_target_properties(zlibstatic PROPERTIES OUTPUT_NAME zlib${SUFFIX})
+         else()
+             set_target_properties(zlibstatic PROPERTIES OUTPUT_NAME z${SUFFIX})
+         endif()
+     elseif(NOT BUILD_SHARED_LIBS)
+         if(MSVC)
+-            set_target_properties(zlib PROPERTIES OUTPUT_NAME zlibstatic${SUFFIX})
++            set_target_properties(zlib PROPERTIES OUTPUT_NAME zlib${SUFFIX})
+         else()
+             set_target_properties(zlib PROPERTIES OUTPUT_NAME z${SUFFIX})
+         endif()

--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -1,0 +1,65 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zlib-ng/zlib-ng
+    REF 83a84faf7a67cb9926947d6b618f141c8020e8e3
+    SHA512 016c45be04d721ddca30bdebd7bc270661b08ff640f5ba3ada454c6be5285f5e3ca0b806860541013f219d2f7c85988545eee79b91dd3212620c867d2241d2a4
+    HEAD_REF develop
+    PATCHES
+        outputname.patch
+)
+
+set(ZLIB_COMPAT ON)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DZLIB_FULL_VERSION=${ZLIB_FULL_VERSION}"
+        -DZLIB_ENABLE_TESTS=OFF
+        -DWITH_NEW_STRATEGIES=ON
+        -DZLIB_COMPAT=${ZLIB_COMPAT}
+    OPTIONS_RELEASE
+        -DWITH_OPTIM=ON
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+# Condition in `WIN32`, from https://github.com/zlib-ng/zlib-ng/blob/2.1.5/CMakeLists.txt#L1081-L1100
+# (dynamic) for `zlib` or (static `MSVC) for `zlibstatic` or default `z`
+# i.e. (windows) and not (static mingw) https://learn.microsoft.com/en-us/vcpkg/maintainers/variables#vcpkg_target_is_system
+if(VCPKG_TARGET_IS_WINDOWS AND (NOT (VCPKG_LIBRARY_LINKAGE STREQUAL static AND VCPKG_TARGET_IS_MINGW)))
+    set(_port_suffix)
+    if(ZLIB_COMPAT)
+        set(_port_suffix "")
+    else()
+        set(_port_suffix "-ng")
+    endif()
+
+    set(_port_output_name)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(_port_output_name "zlib${_port_suffix}")
+    else()
+        set(_port_output_name "zlib${_port_suffix}")
+    endif()
+
+    # CMAKE_DEBUG_POSTFIX from https://github.com/zlib-ng/zlib-ng/blob/2.1.5/CMakeLists.txt#L494
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/zlib${_port_suffix}.pc" " -lz${_port_suffix}" " -l${_port_output_name}")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/zlib${_port_suffix}.pc" " -lz${_port_suffix}" " -l${_port_output_name}d")
+    endif()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+if(ZLIB_COMPAT)
+    set(_cmake_dir "ZLIB")
+else()
+    set(_cmake_dir "zlib-ng")
+endif()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${_cmake_dir})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/zlib/vcpkg.json
+++ b/ports/zlib/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "zlib",
+  "version": "2.2.5",
+  "description": "zlib replacement with optimizations for 'next generation' systems",
+  "homepage": "https://github.com/zlib-ng/zlib-ng",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -20,6 +20,10 @@
       "baseline": "1.0.2",
       "port-version": 0
     },
+    "crashpad": {
+      "baseline": "2021-04-14",
+      "port-version": 0
+    },
     "gettext-libintl": {
       "baseline": "0.22.5",
       "port-version": 1
@@ -42,6 +46,10 @@
     },
     "tracy": {
       "baseline": "0.11.1",
+      "port-version": 0
+    },
+    "zlib": {
+      "baseline": "2.2.5",
       "port-version": 0
     }
   }

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5e4efa1cc689d16e50d2a39f7e060f724ae7396f",
+      "version": "2021-04-14",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/z-/zlib.json
+++ b/versions/z-/zlib.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "cde47ccd02a7703d195f0dfb20b4d6d8cf0a4157",
+      "version": "2.2.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Create ports `crashpad` & `zlib` in the public vcpkg registy

Zlib is actually zlib-ng. We configure our projects to get the zlib port from our registry so that zlib-ng is always used instead of zlib, even by dependencies that we do not control