### PR TITLE
Crashpad handler

### DIFF
--- a/ports/crashpad/crashpadConfig.cmake.in
+++ b/ports/crashpad/crashpadConfig.cmake.in
@@ -17,7 +17,7 @@ if(WIN32)
   set_target_properties(crashpad::handler PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/tools/crashpad_handler.exe)
 	target_compile_definitions(crashpad INTERFACE NOMINMAX)
 elseif(APPLE)
-  set_target_properties(crashpad::crashpad_handler PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/tools/crashpad_handler)
+  set_target_properties(crashpad::handler PROPERTIES IMPORTED_LOCATION ${_IMPORT_PREFIX}/tools/crashpad_handler)
 	list(APPEND CRASHPAD_LIBRARIES ApplicationServices
         CoreFoundation Foundation IOKit Security bsm mig_output)
 endif()

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "crashpad",
   "version": "2021-04-14",
+  "port-version": 1,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -22,7 +22,7 @@
     },
     "crashpad": {
       "baseline": "2021-04-14",
-      "port-version": 0
+      "port-version": 1
     },
     "gettext-libintl": {
       "baseline": "0.22.5",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a9eafaeedd4b90e27b6899880d397c3a554c814",
+      "version": "2021-04-14",
+      "port-version": 1
+    },
+    {
       "git-tree": "5e4efa1cc689d16e50d2a39f7e060f724ae7396f",
       "version": "2021-04-14",
       "port-version": 0


### PR DESCRIPTION
For some reason, the crashpad handler executable target on macOS was set to `crashpad::crashpad_handler` whereas on windows it was set to the much more sensible `crashpad::handler`

Change the macOS `crashpad::crashpad_handler` target to `crashpad::handler` 