### PR TITLE
[Python3] Depend on libb2

### DIFF
--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -66,7 +66,7 @@
           "name": "expat",
           "default-features": false
         },
-          "libb2",
+        "libb2",
         {
           "name": "libffi",
           "default-features": false

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.12.9",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",
@@ -66,6 +66,7 @@
           "name": "expat",
           "default-features": false
         },
+          "libb2",
         {
           "name": "libffi",
           "default-features": false

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -42,7 +42,7 @@
     },
     "python3": {
       "baseline": "3.12.9",
-      "port-version": 1
+      "port-version": 2
     },
     "tracy": {
       "baseline": "0.11.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fa790734c53f653765f49fc47f4e564eace547d",
+      "version": "3.12.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "68dd22ed7bf2f64ec4e4c65ca3a60c4b816c4d0f",
       "version": "3.12.9",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/49916 - Provide libb2 through VCPKG and prevent builds from discovering and linking to a locally installed copies of libb2 when building the blake2 extension.

This change mirrors PR I made in the public vcpkg registry
https://github.com/microsoft/vcpkg/pull/49933
