### PR TITLE
Upgrade scheduler to v1.4.2

### DIFF
--- a/ports/carbon-scheduler/portfile.cmake
+++ b/ports/carbon-scheduler/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/scheduler.git
-  REF 3ad9efb4b3239bf683a387088710b63700c1e18c
+  REF 327303b539aaf1850ebcc4ad73460e3a61855cff
   HEAD_REF main
 )
 

--- a/ports/carbon-scheduler/vcpkg.json
+++ b/ports/carbon-scheduler/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-scheduler",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Provides channels and a scheduler for Greenlet coroutines.",
   "homepage": "https://github.com/carbonengine/scheduler",
   "license": "MIT",
@@ -17,7 +17,7 @@
     },
     {
       "name": "greenlet",
-      "version>=": "3.0.3"
+      "version>=": "3.0.3#1"
     },
     {
       "name": "python3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -13,7 +13,7 @@
       "port-version": 0
     },
     "carbon-scheduler": {
-      "baseline": "1.4.1",
+      "baseline": "1.4.2",
       "port-version": 0
     },
     "ccp-debug-info": {

--- a/versions/c-/carbon-scheduler.json
+++ b/versions/c-/carbon-scheduler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c726a8e9b2ba9d21da3eb56ccb21e341f27b6c90",
+      "version": "1.4.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "fd1982af1a2699de5406f133cbc951975c69d952",
       "version": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
The new version corresponds to the scheduler git tag https://github.com/carbonengine/scheduler/commits/v1.4.2