### PR TITLE
Tracy version 0.13.1

### DIFF
--- a/ports/tracy/downgrade-capstone-5.patch
+++ b/ports/tracy/downgrade-capstone-5.patch
@@ -1,0 +1,92 @@
+diff --git a/profiler/src/profiler/TracySourceView.cpp b/profiler/src/profiler/TracySourceView.cpp
+index c79948b8..2795bf92 100644
+--- a/profiler/src/profiler/TracySourceView.cpp
++++ b/profiler/src/profiler/TracySourceView.cpp
+@@ -4,7 +4,7 @@
+ #include <sstream>
+ #include <stdio.h>
+ 
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ 
+ #include "imgui.h"
+ #include "TracyCharUtil.hpp"
+@@ -713,7 +713,7 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+         rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
+         break;
+     case CpuArchArm64:
+-        rval = cs_open( CS_ARCH_AARCH64, CS_MODE_ARM, &handle );
++        rval = cs_open( CS_ARCH_ARM64, CS_MODE_ARM, &handle );
+         break;
+     default:
+         assert( false );
+@@ -778,9 +778,9 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+                     }
+                     break;
+                 case CpuArchArm64:
+-                    if( detail.aarch64.op_count == 1 && detail.aarch64.operands[0].type == AARCH64_OP_IMM )
++                    if( detail.arm64.op_count == 1 && detail.arm64.operands[0].type == ARM64_OP_IMM )
+                     {
+-                        jumpAddr = (uint64_t)detail.aarch64.operands[0].imm;
++                        jumpAddr = (uint64_t)detail.arm64.operands[0].imm;
+                     }
+                     break;
+                 default:
+@@ -865,18 +865,18 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
+                 }
+                 break;
+             case CpuArchArm64:
+-                for( uint8_t i=0; i<detail.aarch64.op_count; i++ )
++                for( uint8_t i=0; i<detail.arm64.op_count; i++ )
+                 {
+                     uint8_t type = 0;
+-                    switch( detail.aarch64.operands[i].type )
++                    switch( detail.arm64.operands[i].type )
+                     {
+-                    case AARCH64_OP_IMM:
++                    case ARM64_OP_IMM:
+                         type = 0;
+                         break;
+-                    case AARCH64_OP_REG:
++                    case ARM64_OP_REG:
+                         type = 1;
+                         break;
+-                    case AARCH64_OP_MEM:
++                    case ARM64_OP_MEM:
+                         type = 2;
+                         break;
+                     default:
+diff --git a/server/TracyWorker.cpp b/server/TracyWorker.cpp
+index d94a1ab5..437f4a78 100644
+--- a/server/TracyWorker.cpp
++++ b/server/TracyWorker.cpp
+@@ -21,7 +21,7 @@
+ #include <inttypes.h>
+ #include <sys/stat.h>
+ 
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ 
+ #define ZDICT_STATIC_LINKING_ONLY
+ #include <zdict.h>
+@@ -3912,7 +3912,7 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
+         rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
+         break;
+     case CpuArchArm64:
+-        rval = cs_open( CS_ARCH_AARCH64, CS_MODE_ARM, &handle );
++        rval = cs_open( CS_ARCH_ARM64, CS_MODE_ARM, &handle );
+         break;
+     default:
+         assert( false );
+@@ -3952,9 +3952,9 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
+                         }
+                         break;
+                     case CpuArchArm64:
+-                        if( detail.aarch64.op_count == 1 && detail.aarch64.operands[0].type == AARCH64_OP_IMM )
++                        if( detail.arm64.op_count == 1 && detail.arm64.operands[0].type == ARM64_OP_IMM )
+                         {
+-                            callAddr = (uint64_t)detail.aarch64.operands[0].imm;
++                            callAddr = (uint64_t)detail.arm64.operands[0].imm;
+                         }
+                         break;
+                     default:

--- a/ports/tracy/fix-imgui-patch.patch
+++ b/ports/tracy/fix-imgui-patch.patch
@@ -1,0 +1,64 @@
+diff --git a/cmake/imgui-loader.patch b/cmake/imgui-loader.patch
+index 145fa755..71e5d6cb 100644
+--- a/cmake/imgui-loader.patch
++++ b/cmake/imgui-loader.patch
+@@ -1,16 +1,16 @@
+-diff --git i/backends/imgui_impl_opengl3_loader.h w/backends/imgui_impl_opengl3_loader.h
+-index 4ca0536..a1ff572 100644
+---- i/backends/imgui_impl_opengl3_loader.h
+-+++ w/backends/imgui_impl_opengl3_loader.h
+-@@ -180,6 +180,7 @@ typedef khronos_uint8_t GLubyte;
+- #define GL_VERSION                        0x1F02
++diff --git a/backends/imgui_impl_opengl3_loader.h b/backends/imgui_impl_opengl3_loader.h
++index 2c80cc598..1177da586 100644
++--- a/backends/imgui_impl_opengl3_loader.h
+++++ b/backends/imgui_impl_opengl3_loader.h
++@@ -182,6 +182,7 @@ typedef khronos_uint8_t GLubyte;
+  #define GL_EXTENSIONS                     0x1F03
++ #define GL_NEAREST                        0x2600
+  #define GL_LINEAR                         0x2601
+ +#define GL_LINEAR_MIPMAP_LINEAR           0x2703
+  #define GL_TEXTURE_MAG_FILTER             0x2800
+  #define GL_TEXTURE_MIN_FILTER             0x2801
+  #define GL_TEXTURE_WRAP_S                 0x2802
+-@@ -244,8 +245,10 @@ GLAPI void APIENTRY glGenTextures (GLsizei n, GLuint *textures);
++@@ -246,8 +247,10 @@ GLAPI void APIENTRY glGenTextures (GLsizei n, GLuint *textures);
+  #define GL_TEXTURE0                       0x84C0
+  #define GL_ACTIVE_TEXTURE                 0x84E0
+  typedef void (APIENTRYP PFNGLACTIVETEXTUREPROC) (GLenum texture);
+@@ -21,7 +21,7 @@ index 4ca0536..a1ff572 100644
+  #endif
+  #endif /* GL_VERSION_1_3 */
+  #ifndef GL_VERSION_1_4
+-@@ -481,7 +484,7 @@ GL3W_API GL3WglProc imgl3wGetProcAddress(const char *proc);
++@@ -490,7 +493,7 @@ GL3W_API GL3WglProc imgl3wGetProcAddress(const char *proc);
+  
+  /* gl3w internal state */
+  union ImGL3WProcs {
+@@ -30,7 +30,7 @@ index 4ca0536..a1ff572 100644
+      struct {
+          PFNGLACTIVETEXTUREPROC            ActiveTexture;
+          PFNGLATTACHSHADERPROC             AttachShader;
+-@@ -497,6 +500,7 @@ union ImGL3WProcs {
++@@ -506,6 +509,7 @@ union ImGL3WProcs {
+          PFNGLCLEARPROC                    Clear;
+          PFNGLCLEARCOLORPROC               ClearColor;
+          PFNGLCOMPILESHADERPROC            CompileShader;
+@@ -38,7 +38,7 @@ index 4ca0536..a1ff572 100644
+          PFNGLCREATEPROGRAMPROC            CreateProgram;
+          PFNGLCREATESHADERPROC             CreateShader;
+          PFNGLDELETEBUFFERSPROC            DeleteBuffers;
+-@@ -563,6 +567,7 @@ GL3W_API extern union ImGL3WProcs imgl3wProcs;
++@@ -575,6 +579,7 @@ GL3W_API extern union ImGL3WProcs imgl3wProcs;
+  #define glClear                           imgl3wProcs.gl.Clear
+  #define glClearColor                      imgl3wProcs.gl.ClearColor
+  #define glCompileShader                   imgl3wProcs.gl.CompileShader
+@@ -46,7 +46,7 @@ index 4ca0536..a1ff572 100644
+  #define glCreateProgram                   imgl3wProcs.gl.CreateProgram
+  #define glCreateShader                    imgl3wProcs.gl.CreateShader
+  #define glDeleteBuffers                   imgl3wProcs.gl.DeleteBuffers
+-@@ -859,6 +864,7 @@ static const char *proc_names[] = {
++@@ -883,6 +888,7 @@ static const char *proc_names[] = {
+      "glClear",
+      "glClearColor",
+      "glCompileShader",

--- a/ports/tracy/fix-vendor-versions.patch
+++ b/ports/tracy/fix-vendor-versions.patch
@@ -1,0 +1,378 @@
+diff --git a/cmake/server.cmake b/cmake/server.cmake
+index a76d1c13..ec73f0b8 100644
+--- a/cmake/server.cmake
++++ b/cmake/server.cmake
+@@ -29,7 +29,7 @@ list(TRANSFORM TRACY_SERVER_SOURCES PREPEND "${TRACY_SERVER_DIR}/")
+ 
+ add_library(TracyServer STATIC EXCLUDE_FROM_ALL ${TRACY_COMMON_SOURCES} ${TRACY_SERVER_SOURCES})
+ target_include_directories(TracyServer PUBLIC ${TRACY_COMMON_DIR} ${TRACY_SERVER_DIR})
+-target_link_libraries(TracyServer PUBLIC TracyCapstone libzstd PPQSort::PPQSort)
++target_link_libraries(TracyServer PUBLIC capstone::capstone zstd::libzstd PPQSort::PPQSort)
+ if(NO_STATISTICS)
+     target_compile_definitions(TracyServer PUBLIC TRACY_NO_STATISTICS)
+ endif()
+diff --git a/cmake/vendor.cmake b/cmake/vendor.cmake
+index adbd5de9..61683d51 100644
+--- a/cmake/vendor.cmake
++++ b/cmake/vendor.cmake
+@@ -6,7 +6,6 @@ set (ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../")
+ # Dependencies are taken from the system first and if not found, they are pulled with CPM and built from source
+ 
+ include(FindPkgConfig)
+-include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
+ 
+ option(DOWNLOAD_CAPSTONE "Force download capstone" ON)
+ option(DOWNLOAD_GLFW "Force download glfw" OFF)
+@@ -16,105 +15,21 @@ option(DOWNLOAD_PUGIXML "Force download pugixml" OFF)
+ 
+ # capstone
+ 
+-pkg_check_modules(CAPSTONE capstone)
+-if(CAPSTONE_FOUND AND NOT DOWNLOAD_CAPSTONE)
+-    message(STATUS "Capstone found: ${CAPSTONE}")
+-    add_library(TracyCapstone INTERFACE)
+-    target_include_directories(TracyCapstone INTERFACE ${CAPSTONE_INCLUDE_DIRS})
+-    target_link_libraries(TracyCapstone INTERFACE ${CAPSTONE_LINK_LIBRARIES})
+-else()
+-    CPMAddPackage(
+-        NAME capstone
+-        GITHUB_REPOSITORY capstone-engine/capstone
+-        GIT_TAG 6.0.0-Alpha5
+-        OPTIONS
+-            "CAPSTONE_X86_ATT_DISABLE ON"
+-            "CAPSTONE_ALPHA_SUPPORT OFF"
+-            "CAPSTONE_ARC_SUPPORT OFF"
+-            "CAPSTONE_HPPA_SUPPORT OFF"
+-            "CAPSTONE_LOONGARCH_SUPPORT OFF"
+-            "CAPSTONE_M680X_SUPPORT OFF"
+-            "CAPSTONE_M68K_SUPPORT OFF"
+-            "CAPSTONE_MIPS_SUPPORT OFF"
+-            "CAPSTONE_MOS65XX_SUPPORT OFF"
+-            "CAPSTONE_PPC_SUPPORT OFF"
+-            "CAPSTONE_SPARC_SUPPORT OFF"
+-            "CAPSTONE_SYSTEMZ_SUPPORT OFF"
+-            "CAPSTONE_XCORE_SUPPORT OFF"
+-            "CAPSTONE_TRICORE_SUPPORT OFF"
+-            "CAPSTONE_TMS320C64X_SUPPORT OFF"
+-            "CAPSTONE_M680X_SUPPORT OFF"
+-            "CAPSTONE_EVM_SUPPORT OFF"
+-            "CAPSTONE_WASM_SUPPORT OFF"
+-            "CAPSTONE_BPF_SUPPORT OFF"
+-            "CAPSTONE_RISCV_SUPPORT OFF"
+-            "CAPSTONE_SH_SUPPORT OFF"
+-            "CAPSTONE_XTENSA_SUPPORT OFF"
+-            "CAPSTONE_BUILD_MACOS_THIN ON"
+-        EXCLUDE_FROM_ALL TRUE
+-    )
+-    add_library(TracyCapstone INTERFACE)
+-    target_include_directories(TracyCapstone INTERFACE ${capstone_SOURCE_DIR}/include/capstone)
+-    target_link_libraries(TracyCapstone INTERFACE capstone_static)
+-endif()
++find_package(capstone CONFIG)
+ 
+ # GLFW
+ 
+ if(NOT USE_WAYLAND AND NOT EMSCRIPTEN)
+-    pkg_check_modules(GLFW glfw3)
+-    if (GLFW_FOUND AND NOT DOWNLOAD_GLFW)
+-        add_library(TracyGlfw3 INTERFACE)
+-        target_include_directories(TracyGlfw3 INTERFACE ${GLFW_INCLUDE_DIRS})
+-        target_link_libraries(TracyGlfw3 INTERFACE ${GLFW_LINK_LIBRARIES})
+-    else()
+-        CPMAddPackage(
+-            NAME glfw
+-            GITHUB_REPOSITORY glfw/glfw
+-            GIT_TAG 3.4
+-            OPTIONS
+-                "GLFW_BUILD_EXAMPLES OFF"
+-                "GLFW_BUILD_TESTS OFF"
+-                "GLFW_BUILD_DOCS OFF"
+-                "GLFW_INSTALL OFF"
+-            EXCLUDE_FROM_ALL TRUE
+-        )
+-        add_library(TracyGlfw3 INTERFACE)
+-        target_link_libraries(TracyGlfw3 INTERFACE glfw)
+-    endif()
++    find_package(glfw3 CONFIG)
+ endif()
+ 
+ # freetype
+ 
+-pkg_check_modules(FREETYPE freetype2)
+-if (FREETYPE_FOUND AND NOT DOWNLOAD_FREETYPE)
+-    add_library(TracyFreetype INTERFACE)
+-    target_include_directories(TracyFreetype INTERFACE ${FREETYPE_INCLUDE_DIRS})
+-    target_link_libraries(TracyFreetype INTERFACE ${FREETYPE_LINK_LIBRARIES})
+-else()
+-    CPMAddPackage(
+-        NAME freetype
+-        GITHUB_REPOSITORY freetype/freetype
+-        GIT_TAG VER-2-14-1
+-        OPTIONS
+-            "FT_DISABLE_HARFBUZZ ON"
+-            "FT_WITH_HARFBUZZ OFF"
+-        EXCLUDE_FROM_ALL TRUE
+-    )
+-    add_library(TracyFreetype INTERFACE)
+-    target_link_libraries(TracyFreetype INTERFACE freetype)
+-endif()
++find_package(Freetype)
+ 
+ # Zstd
+ 
+-CPMAddPackage(
+-    NAME zstd
+-    GITHUB_REPOSITORY facebook/zstd
+-    GIT_TAG v1.5.7
+-    OPTIONS
+-        "ZSTD_BUILD_SHARED OFF"
+-    EXCLUDE_FROM_ALL TRUE
+-    SOURCE_SUBDIR build/cmake
+-)
++find_package(zstd CONFIG)
+ 
+ # Diff Template Library
+ 
+@@ -134,169 +49,70 @@ target_include_directories(TracyGetOpt PUBLIC ${GETOPT_DIR})
+ 
+ # ImGui
+ 
+-CPMAddPackage(
+-    NAME ImGui
+-    GITHUB_REPOSITORY ocornut/imgui
+-    GIT_TAG v1.92.5-docking
+-    DOWNLOAD_ONLY TRUE
+-    PATCHES
+-        "${CMAKE_CURRENT_LIST_DIR}/imgui-emscripten.patch"
+-        "${CMAKE_CURRENT_LIST_DIR}/imgui-loader.patch"
+-)
+-
+-set(IMGUI_SOURCES
+-    imgui_widgets.cpp
+-    imgui_draw.cpp
+-    imgui_demo.cpp
+-    imgui.cpp
+-    imgui_tables.cpp
+-    misc/freetype/imgui_freetype.cpp
+-    backends/imgui_impl_opengl3.cpp
+-)
+-
+-list(TRANSFORM IMGUI_SOURCES PREPEND "${ImGui_SOURCE_DIR}/")
+-
+-add_library(TracyImGui STATIC EXCLUDE_FROM_ALL ${IMGUI_SOURCES})
+-target_include_directories(TracyImGui PUBLIC ${ImGui_SOURCE_DIR})
+-target_link_libraries(TracyImGui PUBLIC TracyFreetype)
+-target_compile_definitions(TracyImGui PRIVATE "IMGUI_ENABLE_FREETYPE")
+-#target_compile_definitions(TracyImGui PUBLIC "IMGUI_DISABLE_OBSOLETE_FUNCTIONS")
+-
+-if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND LEGACY)
+-    find_package(X11 REQUIRED)
+-    target_link_libraries(TracyImGui PUBLIC ${X11_LIBRARIES})
+-endif()
++if (ImGui_SOURCE_DIR)
++    set(IMGUI_SOURCES
++        imgui_widgets.cpp
++        imgui_draw.cpp
++        imgui_demo.cpp
++        imgui.cpp
++        imgui_tables.cpp
++        misc/freetype/imgui_freetype.cpp
++        backends/imgui_impl_opengl3.cpp
++    )
+ 
+-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+-    target_compile_definitions(TracyImGui PRIVATE "IMGUI_DISABLE_DEBUG_TOOLS" "IMGUI_DISABLE_DEMO_WINDOWS")
+-endif()
++    list(TRANSFORM IMGUI_SOURCES PREPEND "${ImGui_SOURCE_DIR}/")
+ 
+-# NFD
++    add_library(TracyImGui STATIC EXCLUDE_FROM_ALL ${IMGUI_SOURCES})
++    target_include_directories(TracyImGui PUBLIC ${ImGui_SOURCE_DIR})
++    target_link_libraries(TracyImGui PUBLIC Freetype::Freetype)
++    target_compile_definitions(TracyImGui PRIVATE "IMGUI_ENABLE_FREETYPE")
++    #target_compile_definitions(TracyImGui PUBLIC "IMGUI_DISABLE_OBSOLETE_FUNCTIONS")
+ 
+-if(NOT NO_FILESELECTOR AND NOT EMSCRIPTEN)
+-    if(GTK_FILESELECTOR)
+-        set(NFD_PORTAL OFF)
+-    else()
+-        set(NFD_PORTAL ON)
++    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND LEGACY)
++        find_package(X11 REQUIRED)
++        target_link_libraries(TracyImGui PUBLIC ${X11_LIBRARIES})
+     endif()
+ 
+-    CPMAddPackage(
+-        NAME nfd
+-        GITHUB_REPOSITORY btzy/nativefiledialog-extended
+-        GIT_TAG v1.2.1
+-        EXCLUDE_FROM_ALL TRUE
+-        OPTIONS
+-            "NFD_PORTAL ${NFD_PORTAL}"
+-    )
++    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
++        target_compile_definitions(TracyImGui PRIVATE "IMGUI_DISABLE_DEBUG_TOOLS" "IMGUI_DISABLE_DEMO_WINDOWS")
++    endif()
+ endif()
+ 
++# NFD
++
++find_package(nfd CONFIG)
++
+ # PPQSort
+ 
+-CPMAddPackage(
+-    NAME PPQSort
+-    GITHUB_REPOSITORY GabTux/PPQSort
+-    VERSION 1.0.6
+-    PATCHES
+-        "${CMAKE_CURRENT_LIST_DIR}/ppqsort-nodebug.patch"
+-    EXCLUDE_FROM_ALL TRUE
+-)
++find_package(PPQSort CONFIG)
+ 
+ # json
+ 
+-CPMAddPackage(
+-    NAME json
+-    GITHUB_REPOSITORY nlohmann/json
+-    GIT_TAG v3.12.0
+-    EXCLUDE_FROM_ALL TRUE
+-)
++find_package(nlohmann_json CONFIG)
+ 
+ # md4c
+ 
+-CPMAddPackage(
+-    NAME md4c
+-    GITHUB_REPOSITORY mity/md4c
+-    GIT_TAG release-0.5.2
+-    EXCLUDE_FROM_ALL TRUE
+-)
++find_package(md4c CONFIG)
+ 
+ if(NOT EMSCRIPTEN)
+ 
+     # base64
+ 
+-    set(BUILD_SHARED_LIBS_SAVE ${BUILD_SHARED_LIBS})
+-    set(BUILD_SHARED_LIBS OFF)
+-    CPMAddPackage(
+-        NAME base64
+-        GITHUB_REPOSITORY aklomp/base64
+-        GIT_TAG v0.5.2
+-        OPTIONS
+-            "BASE64_BUILD_CLI OFF"
+-            "BASE64_WITH_OpenMP OFF"
+-        EXCLUDE_FROM_ALL TRUE
+-    )
+-    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVE})
++    find_package(base64 CONFIG)
+ 
+     # tidy
+ 
+-    CPMAddPackage(
+-        NAME tidy
+-        GITHUB_REPOSITORY htacg/tidy-html5
+-        GIT_TAG 5.8.0
+-        PATCHES
+-            "${CMAKE_CURRENT_LIST_DIR}/tidy-cmake.patch"
+-        EXCLUDE_FROM_ALL TRUE
+-    )
++    find_package(unofficial-tidy-html5 CONFIG)
+ 
+     # usearch
+ 
+-    CPMAddPackage(
+-        NAME usearch
+-        GITHUB_REPOSITORY unum-cloud/usearch
+-        GIT_TAG v2.21.3
+-        EXCLUDE_FROM_ALL TRUE
+-    )
++    find_package(usearch CONFIG)
+ 
+     # pugixml
+ 
+-    pkg_check_modules(PUGIXML pugixml)
+-    if (PUGIXML_FOUND AND NOT DOWNLOAD_PUGIXML)
+-        add_library(TracyPugixml INTERFACE)
+-        target_include_directories(TracyPugixml INTERFACE ${PUGIXML_INCLUDE_DIRS})
+-        target_link_libraries(TracyPugixml INTERFACE ${PUGIXML_LINK_LIBRARIES})
+-    else()
+-        CPMAddPackage(
+-            NAME pugixml
+-            GITHUB_REPOSITORY zeux/pugixml
+-            GIT_TAG v1.15
+-            EXCLUDE_FROM_ALL TRUE
+-        )
+-        add_library(TracyPugixml INTERFACE)
+-        target_link_libraries(TracyPugixml INTERFACE pugixml)
+-    endif()
++    find_package(pugixml CONFIG)
+ 
+     # libcurl
+ 
+-    pkg_check_modules(LIBCURL libcurl>=7.87.0)
+-    if (LIBCURL_FOUND AND NOT DOWNLOAD_LIBCURL)
+-        add_library(TracyLibcurl INTERFACE)
+-        target_include_directories(TracyLibcurl INTERFACE ${LIBCURL_INCLUDE_DIRS})
+-        target_link_libraries(TracyLibcurl INTERFACE ${LIBCURL_LINK_LIBRARIES})
+-    else()
+-        CPMAddPackage(
+-            NAME libcurl
+-            GITHUB_REPOSITORY curl/curl
+-            GIT_TAG curl-8_17_0
+-            OPTIONS
+-                "BUILD_STATIC_LIBS ON"
+-                "BUILD_SHARED_LIBS OFF"
+-                "HTTP_ONLY ON"
+-                "CURL_ZSTD OFF"
+-                "CURL_USE_LIBPSL OFF"
+-            EXCLUDE_FROM_ALL TRUE
+-        )
+-        add_library(TracyLibcurl INTERFACE)
+-        target_link_libraries(TracyLibcurl INTERFACE libcurl_static)
+-        target_include_directories(TracyLibcurl INTERFACE ${libcurl_SOURCE_DIR}/include)
+-    endif()
+-
++    find_package(CURL)
+ endif()
+diff --git a/profiler/CMakeLists.txt b/profiler/CMakeLists.txt
+index 1681a64b..01043d3e 100644
+--- a/profiler/CMakeLists.txt
++++ b/profiler/CMakeLists.txt
+@@ -244,7 +244,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
+     TracyImGui
+     Threads::Threads
+     nlohmann_json::nlohmann_json
+-    md4c
++    md4c::md4c
+ )
+ target_include_directories(${PROJECT_NAME} PRIVATE
+     ${tidy_SOURCE_DIR}/include
+@@ -255,11 +255,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
+ 
+ if(NOT EMSCRIPTEN)
+     target_link_libraries(${PROJECT_NAME} PRIVATE
+-        TracyLibcurl
+-        base64
+-        tidy-static
+-        TracyPugixml
+-        usearch
++        CURL::libcurl
++        aklomp::base64
++        unofficial::tidy-html5::tidy
++        pugixml::pugixml
++        usearch::usearch
+     )
+ endif()
+ 
+@@ -293,7 +293,7 @@ if(NOT EMSCRIPTEN)
+         target_link_libraries(${PROJECT_NAME} PRIVATE nfd::nfd)
+     endif()
+     if(NOT USE_WAYLAND)
+-        target_link_libraries(${PROJECT_NAME} PRIVATE TracyGlfw3)
++        target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
+     endif()
+ endif()
+ 

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -1,18 +1,14 @@
-vcpkg_download_distfile(PATCH_MISSING_CHRONO_INCLUDE
-    URLS https://github.com/wolfpld/tracy/commit/50ff279aaddfd91dc3cdcfd5b7aec3978e63da25.diff?full_index=1
-    SHA512 f9594297ea68612b68bd631497cd312ea01b34280a0f098de0d2b99810149345251a8985a6430337d0b55d2f181ceac10d563b64cfe48f78959f79ec7a6ea3b5
-    FILENAME wolfpld-tracy-PR982.diff
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfpld/tracy
     REF "v${VERSION}"
-    SHA512 d3d99284e3c3172236c3f02b3bc52df111ef650fb8609e54fb3302ece28e55a06cd16713ed532f1e1aad66678ff09639dfc7e01a1e96880fb923b267a1b1b79b
+    SHA512 18c0c589a1d97d0760958c8ab00ba2135bc602fd359d48445b5d8ed76e5b08742d818bb8f835b599149030f455e553a92db86fb7bae049b47820e4401cf9f935
     HEAD_REF master
     PATCHES
         build-tools.patch
-		"${PATCH_MISSING_CHRONO_INCLUDE}"
+        fix-vendor-versions.patch
+        fix-imgui-patch.patch
+        downgrade-capstone-5.patch # tracy wants capstone-6-alpha but vcpkg ships the most recent production capstone, 5.0.6 as of 2026-02-04
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -51,6 +47,19 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS TOOLS_OPTIONS
         gui-tools VCPKG_GUI_TOOLS
 )
 
+if ("gui-tools" IN_LIST FEATURES)
+   vcpkg_from_github(
+       OUT_SOURCE_PATH tracy_imgui_path
+       REPO ocornut/imgui
+       REF "v1.92.5-docking"
+       SHA512 4618b8bd6e65ac27cd7cecb3469d135622279d83f8a580c028231578f7023c4465911c5878ee7e40c2f6dda606aef86f27c3cecfb7bc9a6022bd1d89eed17c29
+       PATCHES
+           "${SOURCE_PATH}/cmake/imgui-emscripten.patch"
+           "${SOURCE_PATH}/cmake/imgui-loader.patch"
+   )
+   list(APPEND TOOLS_OPTIONS "-DImGui_SOURCE_DIR=${tracy_imgui_path}")
+endif()
+
 if("cli-tools" IN_LIST FEATURES OR "gui-tools" IN_LIST FEATURES)
     vcpkg_find_acquire_program(PKGCONFIG)
     list(APPEND TOOLS_OPTIONS "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}")
@@ -61,16 +70,20 @@ vcpkg_cmake_configure(
     OPTIONS
         -DDOWNLOAD_CAPSTONE=OFF
         -DLEGACY=ON
+        -DCMAKE_FIND_PACKAGE_TARGETS_GLOBAL=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         ${FEATURE_OPTIONS}
     OPTIONS_RELEASE
         ${TOOLS_OPTIONS}
     MAYBE_UNUSED_VARIABLES
         DOWNLOAD_CAPSTONE
         LEGACY
+        CMAKE_DISABLE_FIND_PACKAGE_Git
+        ImGui_SOURCE_DIR
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy)
+vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy CONFIG_PATH "lib/cmake/Tracy")
 
 function(tracy_copy_tool tool_name tool_dir)
     vcpkg_copy_tools(
@@ -79,16 +92,19 @@ function(tracy_copy_tool tool_name tool_dir)
     )
 endfunction()
 
+set(TOOLS)
 if("cli-tools" IN_LIST FEATURES)
-    tracy_copy_tool(tracy-capture capture)
-    tracy_copy_tool(tracy-csvexport csvexport)
+    list(APPEND TOOLS tracy-capture tracy-csvexport)
     tracy_copy_tool(tracy-import-chrome import)
     tracy_copy_tool(tracy-import-fuchsia import)
     tracy_copy_tool(tracy-update update)
 endif()
 if("gui-tools" IN_LIST FEATURES)
-    tracy_copy_tool(tracy-profiler profiler)
+    list(APPEND TOOLS tracy-profiler)
 endif()
 
+if(TOOLS)
+    vcpkg_copy_tools(TOOL_NAMES ${TOOLS} AUTO_CLEAN)
+endif()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -36,6 +36,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         libunwind-backtrace              TRACY_LIBUNWIND_BACKTRACE
         symbol-offline-resolve           TRACY_SYMBOL_OFFLINE_RESOLVE
         libbacktrace-elf-dynload-support TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT
+        ignore-memory-faults             TRACY_IGNORE_MEMORY_FAULTS
 
     INVERTED_FEATURES
         crash-handler TRACY_NO_CRASH_HANDLER

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -153,6 +153,9 @@
     "verbose": {
       "description": "Enables verbose logging",
       "supports": "!android"
+    },
+    "ignore-memory-faults": {
+      "description": "Ignore instrumentation errors from memory free events that do not have a matching allocation"
     }
   }
 }

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -90,6 +90,9 @@
         "zstd"
       ]
     },
+    "ignore-memory-faults": {
+      "description": "Ignore instrumentation errors from memory free events that do not have a matching allocation"
+    },
     "libbacktrace-elf-dynload-support": {
       "description": "Enable libbacktrace to support dynamically loaded elfs in symbol resolution resolution after the first symbol resolve operation"
     },
@@ -153,9 +156,6 @@
     "verbose": {
       "description": "Enables verbose logging",
       "supports": "!android"
-    },
-    "ignore-memory-faults": {
-      "description": "Ignore instrumentation errors from memory free events that do not have a matching allocation"
     }
   }
 }

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tracy",
-  "version": "0.11.1",
+  "version": "0.13.1",
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",
@@ -40,12 +40,9 @@
           "default-features": false,
           "platform": "!windows"
         },
-        "freetype",
-        "glfw3",
-        {
-          "name": "tbb",
-          "platform": "!windows"
-        }
+        "nlohmann-json",
+        "ppqsort",
+        "zstd"
       ]
     },
     "crash-handler": {
@@ -61,6 +58,7 @@
       "description": "Build Tracy GUI tool: `profiler` (aka `Tracy` executable)",
       "supports": "!(windows & x86)",
       "dependencies": [
+        "aklomp-base64",
         {
           "name": "capstone",
           "features": [
@@ -69,6 +67,7 @@
             "x86"
           ]
         },
+        "curl",
         {
           "name": "dbus",
           "default-features": false,
@@ -76,10 +75,19 @@
         },
         "freetype",
         "glfw3",
+        "md4c",
+        "nativefiledialog-extended",
+        "nlohmann-json",
+        "ppqsort",
+        "pugixml",
+        "tidy-html5",
         {
-          "name": "tbb",
-          "platform": "!windows"
-        }
+          "name": "usearch",
+          "features": [
+            "fp16"
+          ]
+        },
+        "zstd"
       ]
     },
     "libbacktrace-elf-dynload-support": {
@@ -143,7 +151,8 @@
       "description": "Use lower resolution timers"
     },
     "verbose": {
-      "description": "Enables verbose logging"
+      "description": "Enables verbose logging",
+      "supports": "!android"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -45,7 +45,7 @@
       "port-version": 4
     },
     "tracy": {
-      "baseline": "0.11.1",
+      "baseline": "0.13.1",
       "port-version": 0
     },
     "zlib": {

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4460dafb9b4cdefcf800ae032148d51b5db59faf",
+      "version": "0.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "40611e2fa8291beda5b481dc5bbac61be0911bfd",
       "version": "0.11.1",
       "port-version": 0


### PR DESCRIPTION
Changes the following:
- Tracy port updated based on official microsoft/vcpkg port for version 0.13.1
- Add feature flag for "ignore-memory-faults" (ignoring non-matching allocations on tracy memory free events)
- Fix formatting and update version registry

