### PR TITLE
Update carbon-core port for v2.5.0

### DIFF
--- a/ports/carbon-core/portfile.cmake
+++ b/ports/carbon-core/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/core.git
-  REF 5a01a587f703c49ede310ff9c9f039ad405789f3
+  REF bdae14213dc62bd22aef0fcb6dc2e425370b0eb7
   HEAD_REF main
 )
 

--- a/ports/carbon-core/vcpkg.json
+++ b/ports/carbon-core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-core",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Provides generic low-level functionality and cross-platform abstractions for system calls",
   "homepage": "https://github.com/carbonengine/core",
   "license": "MIT",
@@ -20,7 +20,7 @@
         "no-callstack",
         "on-demand"
       ],
-      "version>=": "0.11.1"
+      "version>=": "0.13.1"
     },
     {
       "name": "vcpkg-cmake",
@@ -38,7 +38,7 @@
         {
           "name": "python3",
           "host": true,
-          "version>=": "3.12.9"
+          "version>=": "3.12.9#1"
         }
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5,7 +5,7 @@
       "port-version": 1
     },
     "carbon-core": {
-      "baseline": "2.4.0",
+      "baseline": "2.5.0",
       "port-version": 0
     },
     "carbon-resources": {

--- a/versions/c-/carbon-core.json
+++ b/versions/c-/carbon-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ed9f58d594d37ad4e8fd05dbfc0ef604d5a0567",
+      "version": "2.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "96869e0e61065ea0f83c046f8d19e88def85366c",
       "version": "2.4.0",
       "port-version": 0


### PR DESCRIPTION
Update the carbon-core port for the new v2.5.0 version
Including dependency version upgrade to v0.13.1 of Tracy.

