### PR TITLE
Add protobuf

### DIFF
--- a/ports/protobuf/export-pyext-target.patch
+++ b/ports/protobuf/export-pyext-target.patch
@@ -1,0 +1,98 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3cc06d57b..eca590b83 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,6 +35,7 @@ option(protobuf_BUILD_EXAMPLES "Build examples" OFF)
+ option(protobuf_BUILD_PROTOBUF_BINARIES "Build protobuf libraries and protoc compiler" ON)
+ option(protobuf_BUILD_PROTOC_BINARIES "Build libprotoc and protoc compiler" ON)
+ option(protobuf_BUILD_LIBPROTOC "Build libprotoc" OFF)
++option(protobuf_BUILD_PYEXT "Build pyext" ON)
+ option(protobuf_BUILD_LIBUPB "Build libupb" ON)
+ option(protobuf_DISABLE_RTTI "Remove runtime type information in the binaries" OFF)
+ option(protobuf_TEST_XML_OUTDIR "Output directory for XML logs from tests." "")
+@@ -338,6 +339,10 @@ if (protobuf_BUILD_CONFORMANCE)
+   include(${protobuf_SOURCE_DIR}/cmake/conformance.cmake)
+ endif (protobuf_BUILD_CONFORMANCE)
+ 
++if(protobuf_BUILD_PYEXT)
++  include(${protobuf_SOURCE_DIR}/cmake/pyext.cmake)
++endif(protobuf_BUILD_PYEXT)
++
+ if (protobuf_INSTALL)
+   include(${protobuf_SOURCE_DIR}/cmake/install.cmake)
+ endif (protobuf_INSTALL)
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 0a31eade0..b08ba2c40 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -41,6 +41,10 @@ if (protobuf_BUILD_LIBUPB)
+   list(APPEND _protobuf_libraries libupb)
+ endif ()
+ 
++if(protobuf_BUILD_PYEXT)
++  list(APPEND _protobuf_libraries pyext)
++endif(protobuf_BUILD_PYEXT)
++
+ foreach(_library ${_protobuf_libraries})
+   if (UNIX AND NOT APPLE)
+     set_property(TARGET ${_library}
+@@ -52,7 +56,8 @@ foreach(_library ${_protobuf_libraries})
+   install(TARGETS ${_library} EXPORT protobuf-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT ${_library})
+ endforeach()
+ 
+ if (protobuf_BUILD_PROTOC_BINARIES)
+@@ -190,3 +195,12 @@ if (protobuf_INSTALL_TESTS)
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
++
++# Install pyext headers
++if(protobuf_BUILD_PYEXT)
++  foreach(pyext_header ${pyext_headers})
++    file(RELATIVE_PATH relative_subdir ${pyext_dir} ${pyext_header})
++    get_filename_component(subdir ${relative_subdir} DIRECTORY)
++    install(FILES ${pyext_header} DESTINATION "include/google/protobuf/pyext/${subdir}")
++  endforeach()
++endif(protobuf_BUILD_PYEXT)
+diff --git a/cmake/pyext.cmake b/cmake/pyext.cmake
+new file mode 100644
+index 000000000..65b1f1af1
+--- /dev/null
++++ b/cmake/pyext.cmake
+@@ -0,0 +1,31 @@
++cmake_policy(SET CMP0057 NEW)
++cmake_policy(SET CMP0074 NEW)
++
++find_package(Python3 COMPONENTS Development REQUIRED)
++
++set(pyext_dir ${CMAKE_SOURCE_DIR}/python/google/protobuf/pyext)
++message("pyext_dir ${pyext_dir}")
++file(GLOB_RECURSE pyext_files
++  LIST_DIRECTORIES false
++  ${pyext_dir}/*.cc
++  ${pyext_dir}/*.h
++)
++
++file(GLOB_RECURSE pyext_headers
++  LIST_DIRECTORIES false
++  ${pyext_dir}/*.h
++)
++
++if(MSVC)
++    # Ignore const string conversion and integer precision loss
++    add_compile_options(/Zc:strictStrings- /wd4244 /wd4267)
++endif()
++
++add_library(pyext STATIC ${pyext_files})
++target_include_directories(pyext PUBLIC
++    $<BUILD_INTERFACE:${protobuf_SOURCE_DIR}/python>
++    $<INSTALL_INTERFACE:include>
++#  ${pyext_dir}
++#  ${protobuf_source_dir}/python
++)
++target_link_libraries(pyext PUBLIC libprotobuf Python3::Python)

--- a/ports/protobuf/fix-constinit-with-clang-cl.patch
+++ b/ports/protobuf/fix-constinit-with-clang-cl.patch
@@ -1,0 +1,14 @@
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index a512b4843..31f1f5a12 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -678,6 +678,9 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
+ #  define PROTOBUF_CONSTINIT
+ #  define PROTOBUF_CONSTEXPR constexpr
+ # endif
++#elif defined(_MSC_VER)  && defined(__clang__)
++#  define PROTOBUF_CONSTINIT
++#  define PROTOBUF_CONSTEXPR constexpr
+ #else
+ # if defined(__cpp_constinit) && !defined(__CYGWIN__)
+ #  define PROTOBUF_CONSTINIT constinit

--- a/ports/protobuf/fix-default-proto-file-path.patch
+++ b/ports/protobuf/fix-default-proto-file-path.patch
@@ -1,0 +1,21 @@
+diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
+index cd95c8b41..d4825180d 100644
+--- a/src/google/protobuf/compiler/command_line_interface.cc
++++ b/src/google/protobuf/compiler/command_line_interface.cc
+@@ -272,12 +272,15 @@ void AddDefaultProtoPaths(
+     paths->emplace_back("", std::move(include_path));
+     return;
+   }
+-  // Check if the upper level directory has an "include" subdirectory.
++  // change "'$/bin' is next to 'include'" assumption to "'$/bin/tools' is next to 'include'"
++  for (int i = 0; i < 2; i++)
++  {
+   pos = path.find_last_of("/\\");
+   if (pos == std::string::npos || pos == 0) {
+     return;
+   }
+   path = path.substr(0, pos);
++  }
+   include_path = absl::StrCat(path, "/include");
+   if (IsInstalledProtoPath(include_path)) {
+     paths->emplace_back("", std::move(include_path));

--- a/ports/protobuf/fix-install-dirs.patch
+++ b/ports/protobuf/fix-install-dirs.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2b9ca8ed6..1881eb221 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,7 @@ endif()
+ 
+ # Project
+ project(protobuf C CXX)
++include(GNUInstallDirs)
+ 
+ if(CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD LESS 17)
+   message(FATAL_ERROR "The minimum supported C++ standard is C++ 17")

--- a/ports/protobuf/fix-static-build.patch
+++ b/ports/protobuf/fix-static-build.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 65765ca29..f5ad69102 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -65,7 +65,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+     endforeach ()
+   endif ()
+   foreach (binary IN LISTS _protobuf_binaries)
+-    if (UNIX AND NOT APPLE)
++    if (UNIX AND NOT APPLE AND NOT protobuf_MSVC_STATIC_RUNTIME)
+       set_property(TARGET ${binary}
+         PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+     elseif (APPLE)
+@@ -85,7 +85,5 @@ set(protobuf_HEADERS
+   ${cpp_features_proto_proto_srcs}
+   ${descriptor_proto_proto_srcs}
+   ${plugin_proto_proto_srcs}
+-  ${java_features_proto_proto_srcs}
+-  ${go_features_proto_proto_srcs}
+ )
+ if (protobuf_BUILD_LIBUPB)
+   list(APPEND protobuf_HEADERS ${libupb_hdrs})

--- a/ports/protobuf/fix-upb.patch
+++ b/ports/protobuf/fix-upb.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 5e816b311..84211495b 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -60,7 +60,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+   install(TARGETS protoc EXPORT protobuf-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc
+     BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+-  if (protobuf_BUILD_LIBUPB)
++  if (0)
+     foreach (generator upb upbdefs upb_minitable)
+       list(APPEND _protobuf_binaries protoc-gen-${generator})
+       install(TARGETS protoc-gen-${generator} EXPORT protobuf-targets
+@@ -93,7 +93,7 @@ set(protobuf_HEADERS
+   ${descriptor_proto_proto_srcs}
+   ${plugin_proto_proto_srcs}
+ )
+-if (protobuf_BUILD_LIBUPB)
++if (0)
+   list(APPEND protobuf_HEADERS ${libupb_hdrs})
+   # Manually install the bootstrap headers
+   install(

--- a/ports/protobuf/fix-utf8-range.patch
+++ b/ports/protobuf/fix-utf8-range.patch
@@ -1,0 +1,71 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2b9ca8ed6..a9798c35e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -274,6 +274,7 @@ endif (protobuf_BUILD_TESTS)
+ include(${protobuf_SOURCE_DIR}/cmake/abseil-cpp.cmake)
+ 
+ if (protobuf_BUILD_PROTOBUF_BINARIES)
++  find_package(utf8_range CONFIG REQUIRED)
+   include(${protobuf_SOURCE_DIR}/cmake/utf8_range.cmake)
+   include(${protobuf_SOURCE_DIR}/cmake/libprotobuf-lite.cmake)
+   if (NOT DEFINED protobuf_LIB_PROTOBUF_LITE)
+diff --git a/cmake/libprotobuf-lite.cmake b/cmake/libprotobuf-lite.cmake
+index 6a923f6c8..d910c8499 100644
+--- a/cmake/libprotobuf-lite.cmake
++++ b/cmake/libprotobuf-lite.cmake
+@@ -43,4 +43,4 @@ set_target_properties(libprotobuf-lite PROPERTIES
+ )
+ add_library(protobuf::libprotobuf-lite ALIAS libprotobuf-lite)
+ 
+-target_link_libraries(libprotobuf-lite PRIVATE utf8_validity)
++target_link_libraries(libprotobuf-lite PRIVATE utf8_range::utf8_validity)
+diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
+index 22df1fd14..ea9a1054b 100644
+--- a/cmake/libprotobuf.cmake
++++ b/cmake/libprotobuf.cmake
+@@ -45,4 +45,4 @@ set_target_properties(libprotobuf PROPERTIES
+ )
+ add_library(protobuf::libprotobuf ALIAS libprotobuf)
+ 
+-target_link_libraries(libprotobuf PUBLIC utf8_validity)
++target_link_libraries(libprotobuf PUBLIC utf8_range::utf8_validity)
+diff --git a/cmake/libupb.cmake b/cmake/libupb.cmake
+index 1cbbaa209..4feb0345e 100644
+--- a/cmake/libupb.cmake
++++ b/cmake/libupb.cmake
+@@ -48,4 +48,4 @@ set_target_properties(libupb PROPERTIES
+     VISIBILITY_INLINES_HIDDEN ON
+ )
+ add_library(protobuf::libupb ALIAS libupb)
+-target_link_libraries(libupb PRIVATE utf8_range)
++target_link_libraries(libupb PRIVATE utf8_range::utf8_range)
+diff --git a/cmake/upb_generators.cmake b/cmake/upb_generators.cmake
+index 7a55f851e..de897a079 100644
+--- a/cmake/upb_generators.cmake
++++ b/cmake/upb_generators.cmake
+@@ -24,7 +24,7 @@ foreach(generator upb upbdefs upb_minitable)
+   endif()
+   target_link_libraries(protoc-gen-${generator}
+     libprotobuf
+-    utf8_validity
++    utf8_range::utf8_validity
+     ${protobuf_LIB_UPB}
+     ${protobuf_ABSL_USED_TARGETS}
+   )
+diff --git a/cmake/utf8_range.cmake b/cmake/utf8_range.cmake
+index f411a8c5b..21bf8235b 100644
+--- a/cmake/utf8_range.cmake
++++ b/cmake/utf8_range.cmake
+@@ -1,4 +1,4 @@
+-if (NOT TARGET utf8_range)
++if (0)
+   set(utf8_range_ENABLE_TESTS OFF CACHE BOOL "Disable utf8_range tests")
+ 
+   if (NOT EXISTS "${protobuf_SOURCE_DIR}/third_party/utf8_range/CMakeLists.txt")
+@@ -12,4 +12,4 @@ if (NOT TARGET utf8_range)
+   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/utf8_range)
+ endif ()
+ 
+-set(_protobuf_FIND_UTF8_RANGE "if(NOT TARGET utf8_range)\n  find_package(utf8_range CONFIG)\nendif()")
++set(_protobuf_FIND_UTF8_RANGE "if(NOT TARGET utf8_range::utf8_range)\n  find_package(utf8_range CONFIG)\nendif()")

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,0 +1,141 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO protocolbuffers/protobuf
+    REF "v33.4"
+    SHA512 540059a93721447cf4723bcca06e91c43a4399cb366c05bf84e9d8e2c439f3107ba17803f9d912549b54c471f2dcc4c9fc834145ec441dff31ca24f9a3543aa9
+    HEAD_REF master
+    PATCHES
+        fix-static-build.patch
+        fix-default-proto-file-path.patch
+        export-pyext-target.patch
+        fix-utf8-range.patch
+        fix-install-dirs.patch
+        fix-constinit-with-clang-cl.patch
+        fix-upb.patch
+)
+
+string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" protobuf_BUILD_SHARED_LIBS)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" protobuf_MSVC_STATIC_RUNTIME)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        zlib protobuf_WITH_ZLIB
+        pyext protobuf_BUILD_PYEXT
+)
+
+if(VCPKG_TARGET_IS_UWP)
+    set(protobuf_BUILD_LIBPROTOC OFF)
+else()
+    set(protobuf_BUILD_LIBPROTOC ON)
+endif()
+
+if (VCPKG_DOWNLOAD_MODE)
+    # download PKGCONFIG in download mode which is used in `vcpkg_fixup_pkgconfig()` at the end of this script.
+    # download it here because `vcpkg_cmake_configure()` halts execution in download mode when running configure process.
+    vcpkg_find_acquire_program(PKGCONFIG)
+endif()
+
+# Delete language backends we aren't targeting to reduce false positives in automated dependency
+# detectors like Dependabot.
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/csharp"
+    "${SOURCE_PATH}/java"
+    "${SOURCE_PATH}/lua"
+    "${SOURCE_PATH}/objectivec"
+    "${SOURCE_PATH}/php"
+    "${SOURCE_PATH}/ruby"
+    "${SOURCE_PATH}/rust"
+    "${SOURCE_PATH}/go"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=17
+        -Dprotobuf_BUILD_SHARED_LIBS=${protobuf_BUILD_SHARED_LIBS}
+        -Dprotobuf_MSVC_STATIC_RUNTIME=${protobuf_MSVC_STATIC_RUNTIME}
+        -Dprotobuf_BUILD_TESTS=OFF
+        -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
+        -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
+        -Dprotobuf_BUILD_LIBPROTOC=${protobuf_BUILD_LIBPROTOC}
+        -Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON
+        -Dprotobuf_BUILD_LIBUPB=${protobuf_BUILD_LIBPROTOC}
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+if(protobuf_BUILD_PROTOC_BINARIES)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_copy_tools(TOOL_NAMES protoc AUTO_CLEAN)
+    else()
+        string(REPLACE "." ";" VERSION_LIST ${VERSION})
+        list(GET VERSION_LIST 1 VERSION_MINOR)
+        list(GET VERSION_LIST 2 VERSION_PATCH)
+        vcpkg_copy_tools(TOOL_NAMES protoc protoc-${VERSION_MINOR}.${VERSION_PATCH}.0 AUTO_CLEAN)
+    endif()
+else()
+    file(COPY "${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
+endif()
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-config.cmake"
+    "if(protobuf_MODULE_COMPATIBLE)"
+    "if(protobuf_MODULE_COMPATIBLE OR CMAKE_FIND_PACKAGE_NAME STREQUAL \"Protobuf\")"
+)
+if(NOT protobuf_BUILD_LIBPROTOC)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-module.cmake"
+        "_protobuf_find_libraries(Protobuf_PROTOC protoc)"
+        ""
+    )
+endif()
+
+vcpkg_cmake_config_fixup()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/google/protobuf/port_def.inc"
+        "\#ifdef PROTOBUF_PORT_"
+        "\#ifndef PROTOBUF_USE_DLLS\n\#define PROTOBUF_USE_DLLS\n\#endif // PROTOBUF_USE_DLLS\n\n\#ifdef PROTOBUF_PORT_"
+    )
+endif()
+
+vcpkg_copy_pdbs()
+
+function(replace_package_string package)
+    set(debug_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${package}.pc")
+    set(release_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${package}.pc")
+
+    if(EXISTS "${release_file}")
+        vcpkg_replace_string("${release_file}" "absl_abseil_dll" "abseil_dll" IGNORE_UNCHANGED)
+        if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+            vcpkg_replace_string("${release_file}" "-l${package}" "-llib${package}" IGNORE_UNCHANGED)
+        endif()
+    endif()
+
+    if(EXISTS "${debug_file}")
+        vcpkg_replace_string("${debug_file}" "absl_abseil_dll" "abseil_dll" IGNORE_UNCHANGED)
+        if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+            vcpkg_replace_string("${debug_file}" "-l${package}" "-llib${package}d" IGNORE_UNCHANGED)
+        else()
+            vcpkg_replace_string("${debug_file}" "-l${package}" "-l${package}d" IGNORE_UNCHANGED)
+        endif()
+    endif()
+endfunction()
+
+set(packages protobuf protobuf-lite)
+foreach(package IN LISTS packages)
+    replace_package_string("${package}")
+endforeach()
+
+
+vcpkg_fixup_pkgconfig()
+
+if(NOT protobuf_BUILD_PROTOC_BINARIES)
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/protobuf-targets-vcpkg-protoc.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-targets-vcpkg-protoc.cmake" COPYONLY)
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/protobuf/protobuf-targets-vcpkg-protoc.cmake
+++ b/ports/protobuf/protobuf-targets-vcpkg-protoc.cmake
@@ -1,0 +1,8 @@
+# Create imported target protobuf::protoc
+add_executable(protobuf::protoc IMPORTED)
+
+# Import target "protobuf::protoc" for configuration "Release"
+set_property(TARGET protobuf::protoc APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+set_target_properties(protobuf::protoc PROPERTIES
+    IMPORTED_LOCATION_RELEASE "${Protobuf_PROTOC_EXECUTABLE}"
+)

--- a/ports/protobuf/vcpkg-cmake-wrapper.cmake
+++ b/ports/protobuf/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,3 @@
+find_program(Protobuf_PROTOC_EXECUTABLE NAMES protoc PATHS "${CMAKE_CURRENT_LIST_DIR}/../../../@HOST_TRIPLET@/tools/protobuf" NO_DEFAULT_PATH)
+
+_find_package(${ARGS} CONFIG)

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,0 +1,40 @@
+{
+  "name": "protobuf",
+  "version": "6.33.4",
+  "description": "Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data.",
+  "homepage": "https://github.com/protocolbuffers/protobuf",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    "abseil",
+    {
+      "name": "protobuf",
+      "host": true
+    },
+    "utf8-range",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "pyext": {
+      "description": "Export pyext protobuf internals",
+      "dependencies": [
+        {
+          "name": "python3",
+          "version>=": "3.12.9#4"
+        }
+      ]
+    },
+    "zlib": {
+      "description": "ZLib based features like Gzip streams",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -40,6 +40,10 @@
       "baseline": "3.4.7",
       "port-version": 1
     },
+    "protobuf": {
+      "baseline": "6.33.4",
+      "port-version": 0
+    },
     "python3": {
       "baseline": "3.12.9",
       "port-version": 4

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "81c3c59f9b3238523e4b7d3ce912eb79c9f15e7b",
+      "version": "6.33.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add protobuf port at version 6.33.4

This differs from the official protobuf port in the official [microsoft registry](https://github.com/microsoft/vcpkg/tree/master/ports/protobuf) in the pyext feature we've added to support building carbon-grpc

This version of protobuf is the latest at the time of creating this PR. It builds with the MSVC v145 toolchain.

This port existed at an earlier version in the [ccpgames/carbon-vcpkg-registry](https://github.com/ccpgames/carbon-vcpkg-registry) registry. This diff from that version to this is viewable [here as a closed draft PR](https://github.com/ccpgames/carbon-vcpkg-registry/pull/143). 

The upgrade process was:
- I took the official protobuf port in the official [microsoft registry](https://github.com/microsoft/vcpkg/tree/master/ports/protobuf and added it into the registry
- I reacreated our patches from the [ccpgames/carbon-vcpkg-registry protobuf port](https://github.com/ccpgames/carbon-vcpkg-registry/tree/main/ports/protobuf) and created new patch files for the latest protobuf version
- It has been tested to be able to build through VCPKG with the MSVC 145 toolchain