### PR TITLE
Add port for re2c

### DIFF
--- a/ports/re2c/portfile.cmake
+++ b/ports/re2c/portfile.cmake
@@ -1,0 +1,12 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO skvadrik/re2c
+    REF refs/tags/2.2
+    SHA512 59121c599a36b753dd4f306fbf1d9b2a7fadaa8baa88cf0b6b144716fd75ce2884ab45f5a42d8ae5f42a00ceb8c0d9fc5ff9a60125efc58f21231e8c021993bb
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/re2c/vcpkg.json
+++ b/ports/re2c/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "re2c",
+  "version": "2.2",
+  "description": "Lexer generator for C/C++, Go and Rust",
+  "homepage": "https://github.com/skvadrik/re2c",
+  "dependencies": [
+    {
+      "name": "python3",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -44,6 +44,10 @@
       "baseline": "3.12.9",
       "port-version": 4
     },
+    "re2c": {
+      "baseline": "2.2",
+      "port-version": 0
+    },
     "tracy": {
       "baseline": "0.13.1",
       "port-version": 0

--- a/versions/r-/re2c.json
+++ b/versions/r-/re2c.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9c0e529b08154642e8d4ae8bffaa9a7218c6a3c0",
+      "version": "2.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
The carbon-parser library depends on re2c.