### PR TITLE
Add trinity dependency ports

### DIFF
--- a/ports/amd-fidelityfx-cacao/amd-fidelityfx-cacaoConfig.cmake
+++ b/ports/amd-fidelityfx-cacao/amd-fidelityfx-cacaoConfig.cmake
@@ -1,0 +1,5 @@
+add_library(AMD::FidelityFX::CACAO INTERFACE IMPORTED)
+
+set_target_properties(AMD::FidelityFX::CACAO PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/amd-fidelityfx-cacao"
+)

--- a/ports/amd-fidelityfx-cacao/portfile.cmake
+++ b/ports/amd-fidelityfx-cacao/portfile.cmake
@@ -13,7 +13,7 @@ file(COPY ${SOURCE_PATH}/ffx-cacao/inc/ffx_cacao.h DESTINATION ${CURRENT_PACKAGE
 # Install Source
 file(COPY ${SOURCE_PATH}/ffx-cacao/src/ffx_cacao_defines.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
 file(COPY ${SOURCE_PATH}/ffx-cacao/src/ffx_cacao.cpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
-file(COPY ${SOURCE_PATH}/sample/src/Common/Common.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT}/Common/)
+file(COPY ${SOURCE_PATH}/sample/src/Common/Common.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT}/CACAOCommon/)
 
 # Share
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/amd-fidelityfx-cacao/portfile.cmake
+++ b/ports/amd-fidelityfx-cacao/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL git@github.com:GPUOpen-Effects/FidelityFX-CACAO.git
+  REF 0ddca95e6714727a252ead345591ca8f2598f261 # TAG v1.2
+  HEAD_REF master
+)
+
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/license.txt)
+
+# Install Headers
+file(COPY ${SOURCE_PATH}/ffx-cacao/inc/ffx_cacao.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+# Install Source
+file(COPY ${SOURCE_PATH}/ffx-cacao/src/ffx_cacao_defines.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(COPY ${SOURCE_PATH}/ffx-cacao/src/ffx_cacao.cpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(COPY ${SOURCE_PATH}/sample/src/Common/Common.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT}/Common/)
+
+# Share
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/amd-fidelityfx-cacao/usage
+++ b/ports/amd-fidelityfx-cacao/usage
@@ -1,4 +1,4 @@
 amd-fidelityfx-cacao is compatible with built-in CMake targets:
 
-    find_package(amd-fidelityfx-cacao REQUIRED)
+    find_package(amd-fidelityfx-cacao CONFIG REQUIRED)
     target_link_libraries(main PRIVATE AMD::FidelityFX::CACAO)

--- a/ports/amd-fidelityfx-cacao/usage
+++ b/ports/amd-fidelityfx-cacao/usage
@@ -1,0 +1,4 @@
+amd-fidelityfx-cacao is compatible with built-in CMake targets:
+
+    find_package(amd-fidelityfx-cacao REQUIRED)
+    target_link_libraries(main PRIVATE AMD::FidelityFX::CACAO)

--- a/ports/amd-fidelityfx-cacao/vcpkg.json
+++ b/ports/amd-fidelityfx-cacao/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "amd-fidelityfx-cacao",
+  "version": "1.2",
+  "description": "Combined Adaptive Compute Ambient Occlusion.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/amd-fidelityfx-cas/amd-fidelityfx-casConfig.cmake
+++ b/ports/amd-fidelityfx-cas/amd-fidelityfx-casConfig.cmake
@@ -1,0 +1,5 @@
+add_library(AMD::FidelityFX::CAS INTERFACE IMPORTED)
+
+set_target_properties(AMD::FidelityFX::CAS PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/amd-fidelityfx-cas"
+)

--- a/ports/amd-fidelityfx-cas/portfile.cmake
+++ b/ports/amd-fidelityfx-cas/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL git@github.com:GPUOpen-Effects/FidelityFX-CAS.git
+  REF d70012e4afff58e907b0201aac041c8a2679590d # TAG v1.0
+  HEAD_REF master
+)
+
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE.txt)
+
+# Install Headers
+file(COPY ${SOURCE_PATH}/ffx-cas/ffx_a.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(COPY ${SOURCE_PATH}/ffx-cas/ffx_cas.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+# Share
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/amd-fidelityfx-cas/usage
+++ b/ports/amd-fidelityfx-cas/usage
@@ -1,0 +1,4 @@
+amd-fidelityfx-cas is compatible with built-in CMake targets:
+
+    find_package(amd-fidelityfx-cas REQUIRED)
+    target_link_libraries(main PRIVATE AMD::FidelityFX::CAS)

--- a/ports/amd-fidelityfx-cas/usage
+++ b/ports/amd-fidelityfx-cas/usage
@@ -1,4 +1,4 @@
 amd-fidelityfx-cas is compatible with built-in CMake targets:
 
-    find_package(amd-fidelityfx-cas REQUIRED)
+    find_package(amd-fidelityfx-cas CONFIG REQUIRED)
     target_link_libraries(main PRIVATE AMD::FidelityFX::CAS)

--- a/ports/amd-fidelityfx-cas/vcpkg.json
+++ b/ports/amd-fidelityfx-cas/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "amd-fidelityfx-cas",
+  "version": "1.0",
+  "description": "Contrast Adaptive Sharpening.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/amd-fidelityfx-fsr/amd-fidelityfx-fsrConfig.cmake
+++ b/ports/amd-fidelityfx-fsr/amd-fidelityfx-fsrConfig.cmake
@@ -1,0 +1,5 @@
+add_library(AMD::FidelityFX::FSR INTERFACE IMPORTED)
+
+set_target_properties(AMD::FidelityFX::FSR PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/amd-fidelityfx-fsr"
+)

--- a/ports/amd-fidelityfx-fsr/amd-fidelityfx-fsrConfig.cmake
+++ b/ports/amd-fidelityfx-fsr/amd-fidelityfx-fsrConfig.cmake
@@ -1,5 +1,5 @@
-add_library(AMD::FidelityFX::FSR INTERFACE IMPORTED)
+add_library(AMD::FidelityFX::fsr INTERFACE IMPORTED)
 
-set_target_properties(AMD::FidelityFX::FSR PROPERTIES
+set_target_properties(AMD::FidelityFX::fsr PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/amd-fidelityfx-fsr"
 )

--- a/ports/amd-fidelityfx-fsr/portfile.cmake
+++ b/ports/amd-fidelityfx-fsr/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL git@github.com:GPUOpen-Effects/FidelityFX-FSR.git
+  REF a21ffb8f6c13233ba336352bdff293894c706575 # TAG v1.0.2
+  HEAD_REF master
+)
+
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/license.txt)
+
+# Install Headers
+file(COPY ${SOURCE_PATH}/ffx-fsr/ffx_a.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(COPY ${SOURCE_PATH}/ffx-fsr/ffx_fsr1.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+# Share
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/amd-fidelityfx-fsr/usage
+++ b/ports/amd-fidelityfx-fsr/usage
@@ -1,0 +1,4 @@
+amd-fidelityfx-fsr is compatible with built-in CMake targets:
+
+    find_package(amd-fidelityfx-fsr REQUIRED)
+    target_link_libraries(main PRIVATE AMD::FidelityFX::FSR)

--- a/ports/amd-fidelityfx-fsr/usage
+++ b/ports/amd-fidelityfx-fsr/usage
@@ -1,4 +1,4 @@
 amd-fidelityfx-fsr is compatible with built-in CMake targets:
 
-    find_package(amd-fidelityfx-fsr REQUIRED)
-    target_link_libraries(main PRIVATE AMD::FidelityFX::FSR)
+    find_package(amd-fidelityfx-fsr CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE AMD::FidelityFX::fsr)

--- a/ports/amd-fidelityfx-fsr/vcpkg.json
+++ b/ports/amd-fidelityfx-fsr/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "amd-fidelityfx-fsr",
+  "version": "1.0.2",
+  "description": "AMD FidelityFX Super Resolution.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/amd-fidelityfx/cmake/amd-fidelityfxConfig.cmake
+++ b/ports/amd-fidelityfx/cmake/amd-fidelityfxConfig.cmake
@@ -1,10 +1,6 @@
-if(WIN32)
-    add_library(AMD::FidelityFX SHARED IMPORTED)
-    set_target_properties(AMD::FidelityFX PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/amd-fidelityfx"
-        IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/amd_fidelityfx_dx12.lib"
-        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/amd_fidelityfx_dx12.dll"
-    )
-else()
-    add_library(AMD::FidelityFX INTERFACE IMPORTED)
-endif()
+add_library(AMD::FidelityFX SHARED IMPORTED)
+set_target_properties(AMD::FidelityFX PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/amd-fidelityfx"
+    IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/amd_fidelityfx_dx12.lib"
+    IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/amd_fidelityfx_dx12.dll"
+)

--- a/ports/amd-fidelityfx/cmake/amd-fidelityfxConfig.cmake
+++ b/ports/amd-fidelityfx/cmake/amd-fidelityfxConfig.cmake
@@ -1,0 +1,10 @@
+if(WIN32)
+    add_library(AMD::FidelityFX SHARED IMPORTED)
+    set_target_properties(AMD::FidelityFX PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/amd-fidelityfx"
+        IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/amd_fidelityfx_dx12.lib"
+        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/amd_fidelityfx_dx12.dll"
+    )
+else()
+    add_library(AMD::FidelityFX INTERFACE IMPORTED)
+endif()

--- a/ports/amd-fidelityfx/portfile.cmake
+++ b/ports/amd-fidelityfx/portfile.cmake
@@ -1,0 +1,32 @@
+set(DIST_URL "https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/releases/download/v1.1.4/FidelityFX-SDK-v1.1.4.zip")
+set(SHA512 "3f309d5d12374e4a727c635b10529540712f93b870f77e79952245e0a92b18e518cd412edd1fde45156bfa9d7e70b5f6dc79828d2cc9e13c6b00296d8eedcec2")
+
+vcpkg_download_distfile(
+    ZIP_LOC
+    URLS ${DIST_URL}
+    FILENAME fidelityfx
+    SHA512 ${SHA512}
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ZIP_LOC}
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/sdk/LICENSE.txt)
+
+# Install Framework Headers
+file(COPY ${SOURCE_PATH}/ffx-api/include/ffx_api DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+# Install Framework Libs
+file(COPY ${SOURCE_PATH}/PrebuiltSignedDLL/amd_fidelityfx_dx12.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+
+# Install Framework DLLS
+file(COPY ${SOURCE_PATH}/PrebuiltSignedDLL/amd_fidelityfx_dx12.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+
+# Share
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/cmake/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/amd-fidelityfx/usage
+++ b/ports/amd-fidelityfx/usage
@@ -1,4 +1,4 @@
 amd-fidelityfx is compatible with built-in CMake targets:
 
-    find_package(amd-fidelityfx REQUIRED)
+    find_package(amd-fidelityfx CONFIG REQUIRED)
     target_link_libraries(main PRIVATE AMD::FidelityFX)

--- a/ports/amd-fidelityfx/usage
+++ b/ports/amd-fidelityfx/usage
@@ -1,0 +1,4 @@
+amd-fidelityfx is compatible with built-in CMake targets:
+
+    find_package(amd-fidelityfx REQUIRED)
+    target_link_libraries(main PRIVATE AMD::FidelityFX)

--- a/ports/amd-fidelityfx/vcpkg.json
+++ b/ports/amd-fidelityfx/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "amd-fidelityfx",
   "version": "1.1.4",
   "description": "The AMD FSR™ SDK is a collection of heavily optimized technologies that can be used by developers to improve their DirectX® 12 or Vulkan® applications.",
+  "supports": "windows & x64",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/amd-fidelityfx/vcpkg.json
+++ b/ports/amd-fidelityfx/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "amd-fidelityfx",
+  "version": "1.1.4",
+  "description": "The AMD FSR™ SDK is a collection of heavily optimized technologies that can be used by developers to improve their DirectX® 12 or Vulkan® applications.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/intel-xess/intel-xessConfig.cmake
+++ b/ports/intel-xess/intel-xessConfig.cmake
@@ -1,10 +1,6 @@
-if(WIN32)
-    add_library(INTEL::xess SHARED IMPORTED)
-    set_target_properties(INTEL::xess PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/intel-xess"
-        IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libxess.lib"
-        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libxess.dll"
-    )
-else()
-    add_library(INTEL::xess INTERFACE IMPORTED)
-endif()
+add_library(INTEL::xess SHARED IMPORTED)
+set_target_properties(INTEL::xess PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/intel-xess"
+    IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libxess.lib"
+    IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libxess.dll"
+)

--- a/ports/intel-xess/intel-xessConfig.cmake
+++ b/ports/intel-xess/intel-xessConfig.cmake
@@ -1,0 +1,10 @@
+if(WIN32)
+    add_library(INTEL::xess SHARED IMPORTED)
+    set_target_properties(INTEL::xess PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/intel-xess"
+        IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libxess.lib"
+        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libxess.dll"
+    )
+else()
+    add_library(INTEL::xess INTERFACE IMPORTED)
+endif()

--- a/ports/intel-xess/intel-xessConfig.cmake
+++ b/ports/intel-xess/intel-xessConfig.cmake
@@ -1,5 +1,5 @@
-add_library(INTEL::xess SHARED IMPORTED)
-set_target_properties(INTEL::xess PROPERTIES
+add_library(INTEL::Xess SHARED IMPORTED)
+set_target_properties(INTEL::Xess PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/intel-xess"
     IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/libxess.lib"
     IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libxess.dll"

--- a/ports/intel-xess/portfile.cmake
+++ b/ports/intel-xess/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL git@github.com:intel/xess.git
+  REF f03bde3a73b22a85b39d9bc90ccbfcec2b97d611 # TAG v2.0.1
+  HEAD_REF master
+)
+
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE.txt ${SOURCE_PATH}/third-party-programs.txt)
+
+# Install Headers
+file(COPY ${SOURCE_PATH}/inc/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+# Install Libs
+file(COPY ${SOURCE_PATH}/lib/libxess.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+
+# Install Dlls
+file(COPY ${SOURCE_PATH}/bin/libxess.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+
+# Share
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/intel-xess/usage
+++ b/ports/intel-xess/usage
@@ -1,0 +1,4 @@
+intel-xess is compatible with built-in CMake targets:
+
+    find_package(intel-xess REQUIRED)
+    target_link_libraries(main PRIVATE INTEL::xess)

--- a/ports/intel-xess/usage
+++ b/ports/intel-xess/usage
@@ -1,4 +1,4 @@
 intel-xess is compatible with built-in CMake targets:
 
-    find_package(intel-xess REQUIRED)
-    target_link_libraries(main PRIVATE INTEL::xess)
+    find_package(intel-xess CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE INTEL::Xess)

--- a/ports/intel-xess/vcpkg.json
+++ b/ports/intel-xess/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "intel-xess",
   "version": "2.0.1",
   "description": "A set of real-time AI-based technologies that drastically boost your frame rate at the highest visual quality while keeping your game responsive.",
+  "supports": "windows & x64",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/intel-xess/vcpkg.json
+++ b/ports/intel-xess/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "intel-xess",
+  "version": "2.0.1",
+  "description": "A set of real-time AI-based technologies that drastically boost your frame rate at the highest visual quality while keeping your game responsive.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/nvidia-aftermath/cmake/nvidia-aftermathConfig.cmake
+++ b/ports/nvidia-aftermath/cmake/nvidia-aftermathConfig.cmake
@@ -1,0 +1,10 @@
+if(WIN32)
+    add_library(Nvidia::Aftermath SHARED IMPORTED)
+    set_target_properties(Nvidia::Aftermath PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nvidia-aftermath"
+        IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/GFSDK_Aftermath_Lib.x64.lib"
+        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/GFSDK_Aftermath_Lib.x64.dll"
+    )
+else()
+    add_library(Nvidia::Aftermath INTERFACE IMPORTED)
+endif()

--- a/ports/nvidia-aftermath/cmake/nvidia-aftermathConfig.cmake
+++ b/ports/nvidia-aftermath/cmake/nvidia-aftermathConfig.cmake
@@ -1,10 +1,6 @@
-if(WIN32)
-    add_library(Nvidia::Aftermath SHARED IMPORTED)
-    set_target_properties(Nvidia::Aftermath PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nvidia-aftermath"
-        IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/GFSDK_Aftermath_Lib.x64.lib"
-        IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/GFSDK_Aftermath_Lib.x64.dll"
-    )
-else()
-    add_library(Nvidia::Aftermath INTERFACE IMPORTED)
-endif()
+add_library(Nvidia::Aftermath SHARED IMPORTED)
+set_target_properties(Nvidia::Aftermath PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nvidia-aftermath"
+    IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/GFSDK_Aftermath_Lib.x64.lib"
+    IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/GFSDK_Aftermath_Lib.x64.dll"
+)

--- a/ports/nvidia-aftermath/cmake/nvidia-aftermathConfig.cmake
+++ b/ports/nvidia-aftermath/cmake/nvidia-aftermathConfig.cmake
@@ -1,5 +1,5 @@
-add_library(Nvidia::Aftermath SHARED IMPORTED)
-set_target_properties(Nvidia::Aftermath PROPERTIES
+add_library(NVIDIA::Aftermath SHARED IMPORTED)
+set_target_properties(NVIDIA::Aftermath PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/nvidia-aftermath"
     IMPORTED_IMPLIB "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/GFSDK_Aftermath_Lib.x64.lib"
     IMPORTED_LOCATION "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/GFSDK_Aftermath_Lib.x64.dll"

--- a/ports/nvidia-aftermath/portfile.cmake
+++ b/ports/nvidia-aftermath/portfile.cmake
@@ -1,0 +1,32 @@
+set(DIST_URL "https://developer.nvidia.com/rdp/assets/nsight-aftermath-sdk-2021_1-windows-package")
+set(SHA512 "68e4297b0327d5bf51b8ddc3a5fdcb6a1f919075f31f0076e675718b16115f1cf1ec25447f7abc5d0a3dea041f2881a3c6a1bed883f9618124c3a9f757f1483f")
+
+vcpkg_download_distfile(
+    ZIP_LOC
+    URLS ${DIST_URL}
+    FILENAME aftermath
+    SHA512 ${SHA512}
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ZIP_LOC}
+    NO_REMOVE_ONE_LEVEL
+)
+
+vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE)
+
+# Install Headers
+file(COPY ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+# Install Libs
+file(COPY ${SOURCE_PATH}/lib/x64/GFSDK_Aftermath_Lib.x64.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+
+# Install DLLS
+file(COPY ${SOURCE_PATH}/lib/x64/GFSDK_Aftermath_Lib.x64.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+
+# Share
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/cmake/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/nvidia-aftermath/usage
+++ b/ports/nvidia-aftermath/usage
@@ -1,4 +1,4 @@
 nvidia-aftermath is compatible with built-in CMake targets:
 
-    find_package(nvidia-aftermath REQUIRED)
-    target_link_libraries(main PRIVATE Nvidia::Aftermath)
+    find_package(nvidia-aftermath CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE NVIDIA::Aftermath)

--- a/ports/nvidia-aftermath/usage
+++ b/ports/nvidia-aftermath/usage
@@ -1,0 +1,4 @@
+nvidia-aftermath is compatible with built-in CMake targets:
+
+    find_package(nvidia-aftermath REQUIRED)
+    target_link_libraries(main PRIVATE Nvidia::Aftermath)

--- a/ports/nvidia-aftermath/vcpkg.json
+++ b/ports/nvidia-aftermath/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "nvidia-aftermath",
+  "version": "2021.1.0",
+  "description": "NVIDIA® Nsight™ Aftermath is a library that integrates into a D3D12 or Vulkan game’s crash reporter to generate GPU “mini-dumps” when an exception or TDR occurs.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/nvidia-aftermath/vcpkg.json
+++ b/ports/nvidia-aftermath/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "nvidia-aftermath",
   "version": "2021.1.0",
   "description": "NVIDIA® Nsight™ Aftermath is a library that integrates into a D3D12 or Vulkan game’s crash reporter to generate GPU “mini-dumps” when an exception or TDR occurs.",
+  "supports": "windows & x64",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/amd-fidelityfx-cacao.json
+++ b/versions/a-/amd-fidelityfx-cacao.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "aeeb546122013719b570e203ee139b04e49bbe22",
+      "version": "1.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/amd-fidelityfx-cas.json
+++ b/versions/a-/amd-fidelityfx-cas.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "39ae7755b56ec4e5af6f9f17ecd5d98f27a49b72",
+      "version": "1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/amd-fidelityfx-fsr.json
+++ b/versions/a-/amd-fidelityfx-fsr.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ec69e58d6ecbd882d56821c5a9a7d9bd830bc450",
+      "version": "1.0.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/amd-fidelityfx.json
+++ b/versions/a-/amd-fidelityfx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9c531adc35453a762fb5d5b4bb72ccb1414659d4",
+      "version": "1.1.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,5 +1,21 @@
 {
   "default": {
+    "amd-fidelityfx": {
+      "baseline": "1.1.4",
+      "port-version": 0
+    },
+    "amd-fidelityfx-cacao": {
+      "baseline": "1.2",
+      "port-version": 0
+    },
+    "amd-fidelityfx-cas": {
+      "baseline": "1.0",
+      "port-version": 0
+    },
+    "amd-fidelityfx-fsr": {
+      "baseline": "1.0.2",
+      "port-version": 0
+    },
     "bsdiff-drake127": {
       "baseline": "4.3.3",
       "port-version": 1
@@ -52,6 +68,10 @@
       "baseline": "3.0.3",
       "port-version": 1
     },
+    "intel-xess": {
+      "baseline": "2.0.1",
+      "port-version": 0
+    },
     "launchdarkly": {
       "baseline": "3.8.1",
       "port-version": 0
@@ -59,6 +79,10 @@
     "libffi": {
       "baseline": "3.4.7",
       "port-version": 1
+    },
+    "nvidia-aftermath": {
+      "baseline": "2021.1.0",
+      "port-version": 0
     },
     "nvidia-streamline": {
       "baseline": "2.8.0",

--- a/versions/i-/intel-xess.json
+++ b/versions/i-/intel-xess.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3b5b667694c317e2888870f55e2bf35109644c7d",
+      "version": "2.0.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/n-/nvidia-aftermath.json
+++ b/versions/n-/nvidia-aftermath.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d163cc13ff253139af550c81f80e1b69c8acb1b8",
+      "version": "2021.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add external dependencies required for carbon-trinity

NOTE: separate fidelityfx ports used for featuers to match what is
done in p4 vendoring. Possible improvement for the future to unify
under the single amd-fidelityfx port and add features.

* amd-fidelityfx
* amd-fidelityfx-cacao
* amd-fidelityfx-cas
* amd-fidelityfx-fsr
* intel-xess
* nvidia-aftermath