### PR TITLE
Fix trinity external dep ports

### DIFF
--- a/versions/a-/amd-fidelityfx-cacao.json
+++ b/versions/a-/amd-fidelityfx-cacao.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "aeeb546122013719b570e203ee139b04e49bbe22",
+      "git-tree": "51ee32d9ea7cefc64b832615986da47523f911d2",
       "version": "1.2",
       "port-version": 0
     }

--- a/versions/a-/amd-fidelityfx-cas.json
+++ b/versions/a-/amd-fidelityfx-cas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39ae7755b56ec4e5af6f9f17ecd5d98f27a49b72",
+      "git-tree": "a2a899137ebe99bf26434f31e7be4a3c8ac1aa92",
       "version": "1.0",
       "port-version": 0
     }

--- a/versions/a-/amd-fidelityfx-fsr.json
+++ b/versions/a-/amd-fidelityfx-fsr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ec69e58d6ecbd882d56821c5a9a7d9bd830bc450",
+      "git-tree": "9e7512fd0e38d92b04c274a2cf4d4f6d12967a0d",
       "version": "1.0.2",
       "port-version": 0
     }

--- a/versions/a-/amd-fidelityfx.json
+++ b/versions/a-/amd-fidelityfx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9c531adc35453a762fb5d5b4bb72ccb1414659d4",
+      "git-tree": "dc788e407eb6d6213a769d26df8153ab7782a879",
       "version": "1.1.4",
       "port-version": 0
     }

--- a/versions/i-/intel-xess.json
+++ b/versions/i-/intel-xess.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3b5b667694c317e2888870f55e2bf35109644c7d",
+      "git-tree": "5581447bb84f060171c36de5b46e9274260c23a4",
       "version": "2.0.1",
       "port-version": 0
     }

--- a/versions/n-/nvidia-aftermath.json
+++ b/versions/n-/nvidia-aftermath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d163cc13ff253139af550c81f80e1b69c8acb1b8",
+      "git-tree": "7a84bb248393513fc8307373cc47a09172bb62e5",
       "version": "2021.1.0",
       "port-version": 0
     }


### PR DESCRIPTION
Fix broken git-tree for Trintiy Deps

This was fixed using --overwrite-version rather than adding a new port version as this is supposed to be the initial version.

It is worth noting that this is a little hidden when using python tool to update things. It is simple to not notice that further action is required here. It should probably fail more obviously at the end of the script.
