### PR TITLE
Pass -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to libyaml and protobuf 

### DIFF
--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")

--- a/triplets/x64-windows-debug.cmake
+++ b/triplets/x64-windows-debug.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")
@@ -36,6 +40,10 @@ endif ()
 
 if (PORT MATCHES "protobuf")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # only needed for our ancient version of protobuf. Remove this when we upgrade
+    # We can't upgrade without first upgrading our windows toolchain version from v141
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "zlib")

--- a/triplets/x64-windows-internal.cmake
+++ b/triplets/x64-windows-internal.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")
@@ -36,6 +40,10 @@ endif ()
 
 if (PORT MATCHES "protobuf")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # only needed for our ancient version of protobuf. Remove this when we upgrade
+    # We can't upgrade without first upgrading our windows toolchain version from v141
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "zlib")

--- a/triplets/x64-windows-release.cmake
+++ b/triplets/x64-windows-release.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")
@@ -36,6 +40,10 @@ endif ()
 
 if (PORT MATCHES "protobuf")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # only needed for our ancient version of protobuf. Remove this when we upgrade
+    # We can't upgrade without first upgrading our windows toolchain version from v141
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "zlib")

--- a/triplets/x64-windows-trinitydev.cmake
+++ b/triplets/x64-windows-trinitydev.cmake
@@ -24,6 +24,10 @@ endif ()
 
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # Once we upgrade to libyaml-0.2.6 or above, we will no longer need this line
+    # (currently 0.2.6 is only a release candidate and not yet available through VCPKG)
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "curl")
@@ -36,6 +40,10 @@ endif ()
 
 if (PORT MATCHES "protobuf")
     set(VCPKG_LIBRARY_LINKAGE static)
+
+    # only needed for our ancient version of protobuf. Remove this when we upgrade
+    # We can't upgrade without first upgrading our windows toolchain version from v141
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
 if (PORT MATCHES "zlib")


### PR DESCRIPTION
Neither `libyaml` or `protobuf` are able to compile by default with the version of cmake on our build agents

Fixes https://ccpgames.atlassian.net/browse/PLAT-11434
This fix is tested here: https://github.com/ccpgames/carbon-blue/pull/109

Both of these customizations can be removed by upgrading the corresponding package dependency. However!
- We already use the latest libyaml version available.  libyaml has only last week introduced and is still only a release candidate.
- We cannot upgrade the protobuf dependency without first upgrading the version of the MSVC toolchain 