### PR TITLE
Add configuration to build libccd as static library

### DIFF
--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -25,6 +25,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-debug.cmake
+++ b/triplets/x64-windows-debug.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-internal.cmake
+++ b/triplets/x64-windows-internal.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-release.cmake
+++ b/triplets/x64-windows-release.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-windows-trinitydev.cmake
+++ b/triplets/x64-windows-trinitydev.cmake
@@ -30,6 +30,10 @@ if (PORT MATCHES "libyaml")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
 
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
 if (PORT MATCHES "curl")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()


### PR DESCRIPTION
This library could be used by frontier-destiny for static overlap checks for convex meshes. Since this is unlikely to be used by anything outside Destiny, I think it makes sense to link this statically.