### PR TITLE
Add library options for carbon-mesh dependencies to triplet files

### DIFF
--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -52,3 +52,15 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "glslang")
+    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -54,6 +54,8 @@ if (PORT MATCHES "carbon-pdmprotowrapper")
 endif ()
 
 if (PORT MATCHES "glslang")
+    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
+    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
     set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 

--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -57,3 +57,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -57,3 +57,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -57,3 +57,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -57,3 +57,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-windows-debug.cmake
+++ b/triplets/x64-windows-debug.cmake
@@ -61,3 +61,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-windows-internal.cmake
+++ b/triplets/x64-windows-internal.cmake
@@ -61,3 +61,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-windows-release.cmake
+++ b/triplets/x64-windows-release.cmake
@@ -61,3 +61,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()

--- a/triplets/x64-windows-trinitydev.cmake
+++ b/triplets/x64-windows-trinitydev.cmake
@@ -61,3 +61,11 @@ endif()
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()


### PR DESCRIPTION
For libraries:

- **glsllang**: used in tools (executables only, not libraries consumed by other components), required for compiling Vulkan shaders; insists on 10.15 minimal macOS deployment target
- **meshoptimizer**: used by carbon-mesh that prefers to link it statically
- **tinyfiledialogs**: used in tools (executables only, not libraries consumed by other components)
