### PR TITLE
Update Tracy 0.13.1 port

### DIFF
--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-vendor-versions.patch
         fix-imgui-patch.patch
         downgrade-capstone-5.patch # tracy wants capstone-6-alpha but vcpkg ships the most recent production capstone, 5.0.6 as of 2026-02-04
+        pr-1366-on-demand-reconnect-fix.patch  # backporting that PR to our 0.13.1 because without one cannot reattach to the profiler in on-demand mode
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         on-demand                        TRACY_ON_DEMAND
         fibers	                         TRACY_FIBERS
         verbose                          TRACY_VERBOSE
+        no-crash-handler                 TRACY_NO_CRASH_HANDLER  # Change from official port. Previous default crash-handler INVERTED_FEATURE becomes non-default regular FEATURE.
         manual-lifetime                  TRACY_MANUAL_LIFETIME
         delayed-init                     TRACY_DELAYED_INIT
         no-callstack                     TRACY_NO_CALLSTACK
@@ -38,9 +39,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         symbol-offline-resolve           TRACY_SYMBOL_OFFLINE_RESOLVE
         libbacktrace-elf-dynload-support TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT
         ignore-memory-faults             TRACY_IGNORE_MEMORY_FAULTS
-
-    INVERTED_FEATURES
-        crash-handler TRACY_NO_CRASH_HANDLER
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS TOOLS_OPTIONS

--- a/ports/tracy/pr-1366-on-demand-reconnect-fix.patch
+++ b/ports/tracy/pr-1366-on-demand-reconnect-fix.patch
@@ -1,0 +1,27 @@
+From e59601cf1c6f9ad2f70cf4753aa1f645bf6ec956 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Cl=C3=A9ment=20Gr=C3=A9goire?= <lectem@gmail.com>
+Date: Wed, 20 May 2026 17:51:42 +0200
+Subject: [PATCH] Fix ProfilerWorker hang when TRACY_HAS_CALLSTACK is not
+ defined
+
+---
+ public/client/TracyProfiler.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/public/client/TracyProfiler.cpp b/public/client/TracyProfiler.cpp
+index e7b1360a4b..d1a67831a7 100644
+--- a/public/client/TracyProfiler.cpp
++++ b/public/client/TracyProfiler.cpp
+@@ -1971,8 +1971,12 @@ void Profiler::Worker()
+         }
+ 
+ #ifdef TRACY_ON_DEMAND
++#  ifdef TRACY_HAS_CALLSTACK
++        // Only wait on m_symbolsBusy if the symbol worker thread exists; otherwise nobody
++        // ever resets the flag and we'd spin forever on the second connection.
+         while( m_symbolsBusy.load( std::memory_order_acquire ) ) { YieldThread(); }
+         m_symbolsBusy.store( true, std::memory_order_release );
++#  endif
+         const auto currentTime = GetTime();
+         ClearQueues( token );
+         m_connectionId.fetch_add( 1, std::memory_order_release );

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tracy",
   "version": "0.13.1",
+  "port-version": 1,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "license": "BSD-3-Clause",

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -19,9 +19,6 @@
       "host": true
     }
   ],
-  "default-features": [
-    "crash-handler"
-  ],
   "features": {
     "cli-tools": {
       "description": "Build Tracy command-line tools: `capture`, `csvexport`, `import-chrome`, `import-fuchsia` and `update`",
@@ -45,8 +42,8 @@
         "zstd"
       ]
     },
-    "crash-handler": {
-      "description": "Enable crash handler"
+    "no-crash-handler": {
+      "description": "Disable the built-in Tracy crash handler (needed if application already has its own crash handler)"
     },
     "delayed-init": {
       "description": "Enable delayed initialization of the library (init on first call)"

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -43,9 +43,6 @@
         "zstd"
       ]
     },
-    "no-crash-handler": {
-      "description": "Disable the built-in Tracy crash handler (needed if application already has its own crash handler)"
-    },
     "delayed-init": {
       "description": "Enable delayed initialization of the library (init on first call)"
     },
@@ -114,6 +111,9 @@
     },
     "no-context-switch": {
       "description": "Disable capture of context switches"
+    },
+    "no-crash-handler": {
+      "description": "Disable the built-in Tracy crash handler (needed if application already has its own crash handler)"
     },
     "no-exit": {
       "description": "Client executable does not exit until all profile data is sent to server"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -142,7 +142,7 @@
     },
     "tracy": {
       "baseline": "0.13.1",
-      "port-version": 0
+      "port-version": 1
     },
     "zlib": {
       "baseline": "2.2.5",

--- a/versions/t-/tracy.json
+++ b/versions/t-/tracy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f358e08b7d561fd61758b4be66af4dda78cef1eb",
+      "version": "0.13.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "4460dafb9b4cdefcf800ae032148d51b5db59faf",
       "version": "0.13.1",
       "port-version": 0


### PR DESCRIPTION
This PR includes a fix for the reconnect issue we observed in our `TRACY_ON_DEMAND` + `TRACY_NO_CALLSTACK` build, taken from tracy PR 1366. 
Also, this changes the port file to no longer provide `crash-handler` as an inverted default feature. This is because vcpkg's dependency feature resolution approach always enables default features for transitive dependencies. That means all users of the `carbon-core` port would have to explicitly provide a `tracy` dependency to disable the crash-handler default feature.