### PR TITLE
Add libnestegg port

### DIFF
--- a/ports/libnestegg/Makefile.patch
+++ b/ports/libnestegg/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index 9fef2be..674211b 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign 1.11 no-dist-gzip dist-xz subdir-objects
+ ACLOCAL_AMFLAGS = -I m4
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -I.
+-AM_CFLAGS = -ansi -pedantic -Wall -Wextra -Wno-long-long -Wno-unused-parameter -O2 -g
++AM_CFLAGS = -ansi -pedantic -O2 -g
+ 
+ SUBDIRS = docs
+ 

--- a/ports/libnestegg/libnesteggConfig.cmake
+++ b/ports/libnestegg/libnesteggConfig.cmake
@@ -1,0 +1,9 @@
+get_filename_component(_nestegg_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
+add_library(nestegg STATIC IMPORTED)
+set_target_properties(nestegg PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_nestegg_root}/include"
+    IMPORTED_LOCATION "${_nestegg_root}/lib/nestegg.lib"
+)
+
+unset(_nestegg_root)

--- a/ports/libnestegg/portfile.cmake
+++ b/ports/libnestegg/portfile.cmake
@@ -1,0 +1,27 @@
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(PATCHES "")
+
+if(WIN32)
+    list(APPEND PATCHES Makefile.patch)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mozilla/nestegg
+    REF f7a0b7cedc893b6683cf15cb210b1656c086d964
+    SHA512 93aaefab4975823e45da92c5874ea71544f436cde65cae6120f162440fbab4b975351a83a36fddb25665bb039e7cd6ee6d96400f86499a97ce65209752d244c8
+    HEAD_REF master
+    PATCHES ${PATCHES}
+)
+
+vcpkg_make_configure(
+  SOURCE_PATH ${SOURCE_PATH}
+  AUTORECONF
+  LANGUAGES "C"
+)
+
+vcpkg_make_install()
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/${PORT}Config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libnestegg/vcpkg.json
+++ b/ports/libnestegg/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libnestegg",
+  "version-date": "2018-08-09",
+  "description": "WebM demultiplexing library",
+  "homepage": "https://github.com/mozilla/nestegg",
+  "license": "ISC",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -156,6 +156,10 @@
       "baseline": "3.4.7",
       "port-version": 1
     },
+    "libnestegg": {
+      "baseline": "2018-08-09",
+      "port-version": 0
+    },
     "msoledbsql": {
       "baseline": "18.1.0",
       "port-version": 0

--- a/versions/l-/libnestegg.json
+++ b/versions/l-/libnestegg.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e0f6da680f14b30d21fc013d7624865821ae5545",
+      "version-date": "2018-08-09",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Adds a port for nestegg needed by the carbon-videoplayer vcpkg migration.
Tested by building carbon-videoplayer with libnestegg resolved from this registry.

