### PR TITLE
Fix db port

### DIFF
--- a/ports/carbon-db/vcpkg.json
+++ b/ports/carbon-db/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "carbon-db",
   "version": "2.3.1",
+  "port-version": 1,
   "description": "Python exposure for SQL DB Driver",
   "supports": "windows & x64",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -46,7 +46,7 @@
     },
     "carbon-db": {
       "baseline": "2.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "carbon-destiny": {
       "baseline": "3.1.1",

--- a/versions/c-/carbon-db.json
+++ b/versions/c-/carbon-db.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "038b883545e1e13c0840374747cede878ffff861",
+      "version": "2.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "24469462ff19fbbef039e0750f5ba13ab7513b54",
       "version": "2.3.1",
       "port-version": 0


### PR DESCRIPTION
We are getting this error when trying to resolve carbon-db from this registry:
```
error: git failed with exit code: (128).
fatal: failed to unpack tree object 24469462ff19fbbef039e0750f5ba13ab7513b54

note: while loading carbon-db@2.3.1
```

This indicates that there is a problem with this git-tree hash in the registry, which happens to be the latest git-tree hash of carbon-db in `versions/c-/carbon-db.json`

This PR includes a regenerated git-tree hash that should be valid.