### PR TITLE
Ensure freetype, libpng, libsquish & libjpeg-turbo build statically, as they did when they were vendored into perforce

### DIFF
--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -66,3 +66,19 @@ endif ()
 if (PORT MATCHES "tinyfiledialogs")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -69,3 +69,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -69,3 +69,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -69,3 +69,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -69,3 +69,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-debug.cmake
+++ b/triplets/x64-windows-debug.cmake
@@ -73,3 +73,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-internal.cmake
+++ b/triplets/x64-windows-internal.cmake
@@ -73,3 +73,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-release.cmake
+++ b/triplets/x64-windows-release.cmake
@@ -73,3 +73,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-trinitydev.cmake
+++ b/triplets/x64-windows-trinitydev.cmake
@@ -73,3 +73,19 @@ endif ()
 if (PORT MATCHES "civetweb")
     set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()


### PR DESCRIPTION
freetype, libpng, libsquish & libjpeg-turbo  need to be built statically if we are to not introduce any new runtime dependencies for carbon-trinity and imageio
