### PR TITLE
Force static linking of brotli and bzip2

### DIFF
--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -82,3 +82,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -85,3 +85,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -85,3 +85,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -85,3 +85,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -85,3 +85,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-debug.cmake
+++ b/triplets/x64-windows-debug.cmake
@@ -89,3 +89,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-internal.cmake
+++ b/triplets/x64-windows-internal.cmake
@@ -89,3 +89,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-release.cmake
+++ b/triplets/x64-windows-release.cmake
@@ -89,3 +89,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-trinitydev.cmake
+++ b/triplets/x64-windows-trinitydev.cmake
@@ -89,3 +89,11 @@ endif ()
 if (PORT MATCHES "freetype")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()


### PR DESCRIPTION
trinity depends on brotli and bzlip2 dynamically through it's freetype dependency, but this was statically linked before. So we'd rather not have to ship more dlls/dylibs with the client.

This Ensures these two dependencies will link statically with trinity.