### PR TITLE
Add rules to build libogg and libvorbis statically.

### DIFF
--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -90,3 +90,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -93,3 +93,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -93,3 +93,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -93,3 +93,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -93,3 +93,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-debug.cmake
+++ b/triplets/x64-windows-debug.cmake
@@ -97,3 +97,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-internal.cmake
+++ b/triplets/x64-windows-internal.cmake
@@ -97,3 +97,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-release.cmake
+++ b/triplets/x64-windows-release.cmake
@@ -97,3 +97,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-trinitydev.cmake
+++ b/triplets/x64-windows-trinitydev.cmake
@@ -97,3 +97,11 @@ endif ()
 if (PORT MATCHES "bzip2")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()


### PR DESCRIPTION
These are dependencies of videoplayer and were previously statically linked.