### PR TITLE
Add lib vpx and nasm ports

### DIFF
--- a/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
+++ b/ports/libvpx/0003-add-uwp-v142-and-v143-support.patch
@@ -1,0 +1,168 @@
+diff --git a/build/make/configure.sh b/build/make/configure.sh
+index ebaec96a5..c80c14984 100644
+--- a/build/make/configure.sh
++++ b/build/make/configure.sh
+@@ -1092,7 +1092,7 @@ EOF
+           # A number of ARM-based Windows platforms are constrained by their
+           # respective SDKs' limitations. Fortunately, these are all 32-bit ABIs
+           # and so can be selected as 'win32'.
+-          if [ ${tgt_os} = "win32" ]; then
++          if [ ${tgt_os} = "win32" ] || [ ${tgt_isa} = "armv7" ]; then
+             asm_conversion_cmd="${source_path_mk}/build/make/ads2armasm_ms.pl"
+             AS_SFX=.S
+             msvs_arch_dir=arm-msvs
+@@ -1368,6 +1368,9 @@ EOF
+         android)
+           soft_enable realtime_only
+           ;;
++        uwp)
++          enabled gcc && add_cflags -fno-common
++          ;;
+         win*)
+           enabled gcc && add_cflags -fno-common
+           ;;
+@@ -1490,14 +1493,26 @@ EOF
+       fi
+       AS_SFX=.asm
+       case  ${tgt_os} in
++        uwp)
++          if [ ${tgt_isa} = "x86" ] || [ ${tgt_isa} = "armv7" ]; then
++            add_asflags -f win32
++          else
++            add_asflags -f win64
++          fi
++          enabled debug && [ "${AS}" = yasm ] && add_asflags -g cv8
++          enabled debug && [ "${AS}" = nasm ] && add_asflags -gcv8
++          EXE_SFX=.exe
++          ;;
+         win32)
+           add_asflags -f win32
+-          enabled debug && add_asflags -g cv8
++          enabled debug && [ "${AS}" = yasm ] && add_asflags -g cv8
++          enabled debug && [ "${AS}" = nasm ] && add_asflags -gcv8
+           EXE_SFX=.exe
+           ;;
+         win64)
+           add_asflags -f win64
+-          enabled debug && add_asflags -g cv8
++          enabled debug && [ "${AS}" = yasm ] && add_asflags -g cv8
++          enabled debug && [ "${AS}" = nasm ] && add_asflags -gcv8
+           EXE_SFX=.exe
+           ;;
+         linux*|solaris*|android*)
+@@ -1625,6 +1640,8 @@ EOF
+   # Almost every platform uses pthreads.
+   if enabled multithread; then
+     case ${toolchain} in
++      *-uwp-vs*)
++        ;;
+       *-win*-vs*)
+         ;;
+       *-android-gcc)
+diff --git a/build/make/gen_msvs_vcxproj.sh b/build/make/gen_msvs_vcxproj.sh
+index 1e1db05bb..543eb37b2 100755
+--- a/build/make/gen_msvs_vcxproj.sh
++++ b/build/make/gen_msvs_vcxproj.sh
+@@ -310,7 +310,22 @@ generate_vcxproj() {
+         tag_content ProjectGuid "{${guid}}"
+         tag_content RootNamespace ${name}
+         tag_content Keyword ManagedCProj
+-        if [ $vs_ver -ge 12 ] && [ "${platforms[0]}" = "ARM" ]; then
++        if [ $vs_ver -ge 16 ]; then
++            if [[ $target =~ [^-]*-uwp-.* ]]; then
++                # Universal Windows Applications
++                tag_content AppContainerApplication true
++                tag_content ApplicationType "Windows Store"
++                tag_content ApplicationTypeRevision 10.0
++            fi
++            if [[ $target =~ [^-]*-uwp-.* ]] || [ "${platforms[0]}" = "ARM" ] || [ "${platforms[0]}" = "ARM64" ]; then
++                # Default to the latest Windows 10 SDK
++                tag_content WindowsTargetPlatformVersion 10.0
++            else
++                # Minimum supported version of Windows for the desktop
++                tag_content WindowsTargetPlatformVersion 8.1
++            fi
++            tag_content MinimumVisualStudioVersion 16.0
++        elif [ $vs_ver -ge 12 ] && [ "${platforms[0]}" = "ARM" ]; then
+             tag_content AppContainerApplication true
+             # The application type can be one of "Windows Store",
+             # "Windows Phone" or "Windows Phone Silverlight". The
+@@ -412,7 +427,7 @@ generate_vcxproj() {
+                 Condition="'\$(Configuration)|\$(Platform)'=='$config|$plat'"
+             if [ "$name" == "vpx" ]; then
+                 hostplat=$plat
+-                if [ "$hostplat" == "ARM" ]; then
++                if [ "$hostplat" == "ARM" ] && [ $vs_ver -le 15 ]; then
+                     hostplat=Win32
+                 fi
+             fi
+diff --git a/configure b/configure
+index f7225f061..a372a9ae5 100755
+--- a/configure
++++ b/configure
+@@ -106,6 +106,8 @@ all_platforms="${all_platforms} arm64-darwin23-gcc"
+ all_platforms="${all_platforms} arm64-darwin24-gcc"
+ all_platforms="${all_platforms} arm64-darwin25-gcc"
+ all_platforms="${all_platforms} arm64-linux-gcc"
++all_platforms="${all_platforms} arm64-uwp-vs16"
++all_platforms="${all_platforms} arm64-uwp-vs17"
+ all_platforms="${all_platforms} arm64-win64-gcc"
+ all_platforms="${all_platforms} arm64-win64-vs15"
+ all_platforms="${all_platforms} arm64-win64-vs16"
+@@ -117,6 +119,8 @@ all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
+ all_platforms="${all_platforms} armv7-linux-rvct"    #neon Cortex-A8
+ all_platforms="${all_platforms} armv7-linux-gcc"     #neon Cortex-A8
+ all_platforms="${all_platforms} armv7-none-rvct"     #neon Cortex-A8
++all_platforms="${all_platforms} armv7-uwp-vs16"
++all_platforms="${all_platforms} armv7-uwp-vs17"
+ all_platforms="${all_platforms} armv7-win32-gcc"
+ all_platforms="${all_platforms} armv7-win32-vs14"
+ all_platforms="${all_platforms} armv7-win32-vs15"
+@@ -148,6 +152,8 @@ all_platforms="${all_platforms} x86-linux-gcc"
+ all_platforms="${all_platforms} x86-linux-icc"
+ all_platforms="${all_platforms} x86-os2-gcc"
+ all_platforms="${all_platforms} x86-solaris-gcc"
++all_platforms="${all_platforms} x86-uwp-vs16"
++all_platforms="${all_platforms} x86-uwp-vs17"
+ all_platforms="${all_platforms} x86-win32-gcc"
+ all_platforms="${all_platforms} x86-win32-vs14"
+ all_platforms="${all_platforms} x86-win32-vs15"
+@@ -175,6 +181,8 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
+ all_platforms="${all_platforms} x86_64-linux-gcc"
+ all_platforms="${all_platforms} x86_64-linux-icc"
+ all_platforms="${all_platforms} x86_64-solaris-gcc"
++all_platforms="${all_platforms} x86_64-uwp-vs16"
++all_platforms="${all_platforms} x86_64-uwp-vs17"
+ all_platforms="${all_platforms} x86_64-win64-gcc"
+ all_platforms="${all_platforms} x86_64-win64-vs14"
+ all_platforms="${all_platforms} x86_64-win64-vs15"
+@@ -510,11 +518,10 @@ process_targets() {
+     ! enabled multithread && DIST_DIR="${DIST_DIR}-nomt"
+     ! enabled install_docs && DIST_DIR="${DIST_DIR}-nodocs"
+     DIST_DIR="${DIST_DIR}-${tgt_isa}-${tgt_os}"
+-    case "${tgt_os}" in
+-    win*) enabled static_msvcrt && DIST_DIR="${DIST_DIR}mt" || DIST_DIR="${DIST_DIR}md"
+-          DIST_DIR="${DIST_DIR}-${tgt_cc}"
+-          ;;
+-    esac
++    if [[ ${tgt_os} =~ win.* ]] || [ "${tgt_os}" = "uwp" ]; then
++        enabled static_msvcrt && DIST_DIR="${DIST_DIR}mt" || DIST_DIR="${DIST_DIR}md"
++        DIST_DIR="${DIST_DIR}-${tgt_cc}"
++    fi
+     if [ -f "${source_path}/build/make/version.sh" ]; then
+         ver=`"$source_path/build/make/version.sh" --bare "$source_path"`
+         DIST_DIR="${DIST_DIR}-${ver}"
+@@ -603,6 +610,10 @@ process_detect() {
+ 
+             # Specialize windows and POSIX environments.
+             case $toolchain in
++                *-uwp-*)
++                    # Don't check for any headers in UWP builds.
++                    false
++                ;;
+                 *-win*-*)
+                     # Don't check for any headers in Windows builds.
+                     false
+-- 
+2.49.0
+

--- a/ports/libvpx/0004-remove-library-suffixes.patch
+++ b/ports/libvpx/0004-remove-library-suffixes.patch
@@ -1,0 +1,13 @@
+diff --git a/build/make/gen_msvs_vcxproj.sh b/build/make/gen_msvs_vcxproj.sh
+index 916851662..e60405bc9 100755
+--- a/build/make/gen_msvs_vcxproj.sh
++++ b/build/make/gen_msvs_vcxproj.sh
+@@ -394,7 +394,7 @@ generate_vcxproj() {
+               else
+                 config_suffix=""
+               fi
+-              tag_content TargetName "${name}${lib_sfx}${config_suffix}"
++              tag_content TargetName "${name}"
+             fi
+             close_tag PropertyGroup
+         done

--- a/ports/libvpx/0005-dont-expect-gnu-diff.patch
+++ b/ports/libvpx/0005-dont-expect-gnu-diff.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 356bbe26f..7f8c5559b 100755
+--- a/configure
++++ b/configure
+@@ -189,7 +189,7 @@ for t in ${all_targets}; do
+     [ -f "${source_path}/${t}.mk" ] && enable_feature ${t}
+ done
+ 
+-if ! diff --version >/dev/null; then
++if ! hash diff >/dev/null; then
+   die "diff missing: Try installing diffutils via your package manager."
+ fi
+

--- a/ports/libvpx/0006-gen-vcxproj-ignore-unknown-flags.patch
+++ b/ports/libvpx/0006-gen-vcxproj-ignore-unknown-flags.patch
@@ -1,0 +1,11 @@
+--- a/build/make/gen_msvs_vcxproj.sh
++++ b/build/make/gen_msvs_vcxproj.sh
+@@ -209,7 +209,7 @@
+         ;;
+         -l*) libs="${libs}${libs:+ }${opt##-l}.lib"
+         ;;
+-        -*) die_unknown $opt
++        -*) : # Ignore unknown flags (e.g. -O3 leaked from GCC CFLAGS)
+         ;;
+         *)
+             # The paths in file_list are fixed outside of the loop.

--- a/ports/libvpx/0007-msvc-use-Fo-in-toolchain-probe.patch
+++ b/ports/libvpx/0007-msvc-use-Fo-in-toolchain-probe.patch
@@ -1,0 +1,79 @@
+--- a/build/make/configure.sh	2026-05-13 08:17:31.764191365 +0200
++++ b/build/make/configure.sh	2026-05-13 08:18:26.744873378 +0200
+@@ -298,37 +298,71 @@
+   "$@" >>${logfile} 2>&1
+ }
+ 
++# Emit the compiler/linker output flag for the given file.
++# cl.exe (and clang-cl when driven in cl mode) require -Fo<obj> / -Fe<exe> with no separating space;
++# every other compiler uses the GCC-style -o <file>.
++_cc_basename() {
++  local _cc="${1##*/}"
++  _cc="${_cc##*\\}"
++  echo "${_cc%.exe}"
++}
++
++# Convert a path to native Windows form when the compiler is MSVC.
++# MSYS2 temporary paths like /tmp/vpx-conf-1234.o get translated by the MSYS layer to D:\tmp\... which does not exist.
++# cygpath -w produces the real Windows path (e.g. C:\msys64\tmp\...).
++_native_output_path() {
++  case "$(_cc_basename "${1}")" in
++    cl|clang-cl|link) cygpath -w "$2" ;;
++    *)                echo "$2" ;;
++  esac
++}
++
++cc_obj_flag() {
++  case "$(_cc_basename "${CC}")" in
++    cl|clang-cl) echo "-Fo$(_native_output_path "${CC}" "$1")" ;;
++    *)           echo "-o $1" ;;
++  esac
++}
++
++cc_exe_flag() {
++  case "$(_cc_basename "${LD:-${CC}}")" in
++    cl|clang-cl) echo "-Fe$(_native_output_path "${LD:-${CC}}" "$1")" ;;
++    link)        echo "/OUT:$(_native_output_path "${LD:-${CC}}" "$1")" ;;
++    *)           echo "-o $1" ;;
++  esac
++}
++
+ check_cc() {
+   log check_cc "$@"
+   cat >${TMP_C}
+   log_file ${TMP_C}
+-  check_cmd ${CC} ${CFLAGS} "$@" -c -o ${TMP_O} ${TMP_C}
++  check_cmd ${CC} ${CFLAGS} "$@" -c $(cc_obj_flag ${TMP_O}) ${TMP_C}
+ }
+ 
+ check_cxx() {
+   log check_cxx "$@"
+   cat >${TMP_CC}
+   log_file ${TMP_CC}
+-  check_cmd ${CXX} ${CXXFLAGS} "$@" -c -o ${TMP_O} ${TMP_CC}
++  check_cmd ${CXX} ${CXXFLAGS} "$@" -c $(cc_obj_flag ${TMP_O}) ${TMP_CC}
+ }
+ 
+ check_cpp() {
+   log check_cpp "$@"
+   cat > ${TMP_C}
+   log_file ${TMP_C}
+-  check_cmd ${CC} ${CFLAGS} "$@" -E -o ${TMP_O} ${TMP_C}
++  check_cmd ${CC} ${CFLAGS} "$@" -E $(cc_obj_flag ${TMP_O}) ${TMP_C}
+ }
+ 
+ check_ld() {
+   log check_ld "$@"
+   check_cc $@ \
+-    && check_cmd ${LD} ${LDFLAGS} "$@" -o ${TMP_X} ${TMP_O} ${extralibs}
++    && check_cmd ${LD} ${LDFLAGS} "$@" $(cc_exe_flag ${TMP_X}) ${TMP_O} ${extralibs}
+ }
+ 
+ check_lib() {
+   log check_lib "$@"
+   check_cc $@ \
+-    && check_cmd ${LD} ${LDFLAGS} -o ${TMP_X} ${TMP_O} "$@" ${extralibs}
++    && check_cmd ${LD} ${LDFLAGS} $(cc_exe_flag ${TMP_X}) ${TMP_O} "$@" ${extralibs}
+ }
+ 
+ check_header(){

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -1,0 +1,355 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO webmproject/libvpx
+    REF "v${VERSION}"
+    SHA512 07f5e352411d6c0be331706d1835ac89bafbeddcbbac5542b473323766e9e974f4f68b33590f2aa50a7d8d69468a642b508cbb0a7c49a82c9933b07820f9c9d9
+    HEAD_REF master
+    PATCHES
+        0003-add-uwp-v142-and-v143-support.patch
+        0004-remove-library-suffixes.patch
+        0005-dont-expect-gnu-diff.patch
+        0006-gen-vcxproj-ignore-unknown-flags.patch
+        # Candidate upstream fix: makes configure-time toolchain probes use -Fo/-Fe when CC/LD is cl.exe or clang-cl.
+        # Once upstream picks this up (or once we drop --enable-external-build), the MSVC arm64 SVE workaround below can also be removed.
+        0007-msvc-use-Fo-in-toolchain-probe.patch
+)
+
+if(CMAKE_HOST_WIN32)
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES make perl)
+    set(ENV{PATH} "${MSYS_ROOT}/usr/bin;$ENV{PATH}")
+else()
+    vcpkg_find_acquire_program(PERL)
+    get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
+    set(ENV{PATH} "${MSYS_ROOT}/usr/bin:$ENV{PATH}:${PERL_EXE_PATH}")
+endif()
+
+find_program(BASH NAME bash HINTS ${MSYS_ROOT}/usr/bin REQUIRED NO_CACHE)
+
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    if (VCPKG_TARGET_IS_OSX)
+        set(NASM_EXE_PATH "${CURRENT_INSTALLED_DIR}/tools/nasm/")
+    else()
+        vcpkg_find_acquire_program(NASM)
+        get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+    endif()
+    vcpkg_add_to_path(${NASM_EXE_PATH})
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+
+    file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tmp")
+    # Remove stale vpx-* dist directories from previous builds to avoid picking old artifacts.
+    file(GLOB _vpx_stale_dirs "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-*")
+    if(_vpx_stale_dirs)
+        file(REMOVE_RECURSE ${_vpx_stale_dirs})
+    endif()
+
+
+    if(VCPKG_CRT_LINKAGE STREQUAL static)
+        set(LIBVPX_CRT_LINKAGE --enable-static-msvcrt)
+        set(LIBVPX_CRT_SUFFIX mt)
+    else()
+        set(LIBVPX_CRT_SUFFIX md)
+    endif()
+
+    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore AND (VCPKG_PLATFORM_TOOLSET STREQUAL v142 OR VCPKG_PLATFORM_TOOLSET STREQUAL v143))
+        set(LIBVPX_TARGET_OS "uwp")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x86 OR VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+        set(LIBVPX_TARGET_OS "win32")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64 OR VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+        set(LIBVPX_TARGET_OS "win64")
+    endif()
+
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+        set(LIBVPX_TARGET_ARCH "x86-${LIBVPX_TARGET_OS}")
+        set(LIBVPX_ARCH_DIR "Win32")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+        set(LIBVPX_TARGET_ARCH "x86_64-${LIBVPX_TARGET_OS}")
+        set(LIBVPX_ARCH_DIR "x64")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+        set(LIBVPX_TARGET_ARCH "arm64-${LIBVPX_TARGET_OS}")
+        set(LIBVPX_ARCH_DIR "ARM64")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+        set(LIBVPX_TARGET_ARCH "armv7-${LIBVPX_TARGET_OS}")
+        set(LIBVPX_ARCH_DIR "ARM")
+    endif()
+
+    if(VCPKG_PLATFORM_TOOLSET STREQUAL v143)
+        set(LIBVPX_TARGET_VS "vs17")
+    elseif(VCPKG_PLATFORM_TOOLSET STREQUAL v142)
+        set(LIBVPX_TARGET_VS "vs16")
+    else()
+        set(LIBVPX_TARGET_VS "vs15")
+    endif()
+
+    set(OPTIONS --disable-examples --disable-tools --disable-docs --enable-pic --disable-dependency-tracking)
+
+    # Force VS generation to avoids Unix-style rules that break with cl/ar semantics
+    list(APPEND OPTIONS --enable-external-build)
+
+   # Disable SVE/SVE2 probe to avoids missing `<arm_sve.h>` in pure-MSVC.
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+        vcpkg_cmake_get_vars(_libvpx_cmake_vars_file)
+        include("${_libvpx_cmake_vars_file}")
+        if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+            list(APPEND OPTIONS --disable-sve --disable-sve2)
+        endif()
+    endif()
+
+    if("realtime" IN_LIST FEATURES)
+        list(APPEND OPTIONS --enable-realtime-only)
+    endif()
+
+    if("highbitdepth" IN_LIST FEATURES)
+        list(APPEND OPTIONS --enable-vp9-highbitdepth)
+    endif()
+
+    message(STATUS "Generating makefile")
+    file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tmp")
+    vcpkg_execute_required_process(
+        COMMAND
+            ${BASH} --noprofile --norc
+            "${SOURCE_PATH}/configure"
+            --target=${LIBVPX_TARGET_ARCH}-${LIBVPX_TARGET_VS}
+            ${LIBVPX_CRT_LINKAGE}
+            ${OPTIONS}
+            --as=nasm
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tmp"
+        LOGNAME configure-${TARGET_TRIPLET})
+
+    message(STATUS "Generating MSBuild projects")
+    vcpkg_execute_required_process(
+        COMMAND
+            ${BASH} --noprofile --norc -c "make dist"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tmp"
+        LOGNAME generate-${TARGET_TRIPLET})
+
+    vcpkg_msbuild_install(
+        SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tmp"
+        PROJECT_SUBPATH vpx.vcxproj
+    )
+
+    # libvpx's make dist creates a directory with the pattern:
+    #   vpx-[CODEC_FEATURES]-[ARCH][CRT]-[VS]-v[VERSION]
+    # GLOB to find the actual directory.
+    file(GLOB LIBVPX_INCLUDE_DIR_CANDIDATES
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vpx-*${LIBVPX_TARGET_ARCH}${LIBVPX_CRT_SUFFIX}-${LIBVPX_TARGET_VS}-v${VERSION}/include/vpx")
+    list(LENGTH LIBVPX_INCLUDE_DIR_CANDIDATES _vpx_n)
+    if(_vpx_n EQUAL 0)
+        message(FATAL_ERROR "libvpx: no dist include directory found under ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/")
+    elseif(_vpx_n GREATER 1)
+        message(FATAL_ERROR "libvpx: found ${_vpx_n} candidate dist directories; expected exactly one")
+    endif()
+    list(GET LIBVPX_INCLUDE_DIR_CANDIDATES 0 LIBVPX_INCLUDE_DIR)
+    file(
+        INSTALL
+            "${LIBVPX_INCLUDE_DIR}"
+        DESTINATION
+            "${CURRENT_PACKAGES_DIR}/include"
+        RENAME
+            "vpx")
+    if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        set(LIBVPX_PREFIX "${CURRENT_INSTALLED_DIR}")
+        configure_file("${CMAKE_CURRENT_LIST_DIR}/vpx.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/vpx.pc" @ONLY)
+    endif()
+
+    if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        set(LIBVPX_PREFIX "${CURRENT_INSTALLED_DIR}/debug")
+        configure_file("${CMAKE_CURRENT_LIST_DIR}/vpx.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/vpx.pc" @ONLY)
+    endif()
+
+else()
+
+    set(OPTIONS "--disable-examples --disable-tools --disable-docs --disable-unit-tests --enable-pic")
+
+    set(OPTIONS_DEBUG "--enable-debug-libs --enable-debug --prefix=${CURRENT_PACKAGES_DIR}/debug")
+    set(OPTIONS_RELEASE "--prefix=${CURRENT_PACKAGES_DIR}")
+    set(AS_NASM "--as=nasm")
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(OPTIONS "${OPTIONS} --disable-static --enable-shared")
+    else()
+        set(OPTIONS "${OPTIONS} --enable-static --disable-shared")
+    endif()
+
+    if("realtime" IN_LIST FEATURES)
+        set(OPTIONS "${OPTIONS} --enable-realtime-only")
+    endif()
+
+    if("highbitdepth" IN_LIST FEATURES)
+        set(OPTIONS "${OPTIONS} --enable-vp9-highbitdepth")
+    endif()
+
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+        set(LIBVPX_TARGET_ARCH "x86")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+        set(LIBVPX_TARGET_ARCH "x86_64")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+        set(LIBVPX_TARGET_ARCH "armv7")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+        set(LIBVPX_TARGET_ARCH "arm64")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL riscv64)
+        set(LIBVPX_TARGET_ARCH "riscv64")
+    else()
+        message(FATAL_ERROR "libvpx does not support architecture ${VCPKG_TARGET_ARCHITECTURE}")
+    endif()
+
+    vcpkg_cmake_get_vars(cmake_vars_file)
+    include("${cmake_vars_file}")
+
+    # Set environment variables for configure
+    if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "([^\/]*-)gcc$")
+        message(STATUS "Cross-building for ${TARGET_TRIPLET} with ${CMAKE_MATCH_1}")
+        set(ENV{CROSS} ${CMAKE_MATCH_1})
+        unset(AS_NASM)
+    else()
+        set(ENV{CC} ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+        set(ENV{CXX} ${VCPKG_DETECTED_CMAKE_CXX_COMPILER})
+        set(ENV{AR} ${VCPKG_DETECTED_CMAKE_AR})
+        set(ENV{LD} ${VCPKG_DETECTED_CMAKE_CXX_COMPILER})
+        set(ENV{RANLIB} ${VCPKG_DETECTED_CMAKE_RANLIB})
+        set(ENV{STRIP} ${VCPKG_DETECTED_CMAKE_STRIP})
+    endif()
+
+    if(VCPKG_TARGET_IS_MINGW)
+        if(LIBVPX_TARGET_ARCH STREQUAL "x86")
+            set(LIBVPX_TARGET "x86-win32-gcc")
+        else()
+            set(LIBVPX_TARGET "x86_64-win64-gcc")
+        endif()
+    elseif(VCPKG_TARGET_IS_LINUX)
+        # RISCV64 use target generic-gnu
+        if(LIBVPX_TARGET_ARCH STREQUAL "riscv64")
+            set(LIBVPX_TARGET "generic-gnu")
+        else()
+            set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-linux-gcc")
+        endif()
+    elseif(VCPKG_TARGET_IS_ANDROID)
+        set(LIBVPX_TARGET "generic-gnu")
+        # Settings
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+            set(OPTIONS "${OPTIONS} --disable-sse4_1 --disable-avx --disable-avx2 --disable-avx512")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+            set(OPTIONS "${OPTIONS} --disable-avx --disable-avx2 --disable-avx512")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+            set(OPTIONS "${OPTIONS} --enable-thumb --disable-neon")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+            set(OPTIONS "${OPTIONS} --enable-thumb")
+        endif()
+        # Set environment variables for configure
+        set(ENV{AS} ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+        set(ENV{LDFLAGS} "${LDFLAGS} --target=${VCPKG_DETECTED_CMAKE_C_COMPILER_TARGET}")
+        # Set clang target
+        set(OPTIONS "${OPTIONS} --extra-cflags=--target=${VCPKG_DETECTED_CMAKE_C_COMPILER_TARGET} --extra-cxxflags=--target=${VCPKG_DETECTED_CMAKE_CXX_COMPILER_TARGET}")
+        # Unset nasm and let AS do its job
+        unset(AS_NASM)
+    elseif(VCPKG_TARGET_IS_OSX)
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+            set(LIBVPX_TARGET "arm64-darwin20-gcc")
+            if(DEFINED VCPKG_OSX_DEPLOYMENT_TARGET)
+                set(MAC_OSX_MIN_VERSION_CFLAGS --extra-cflags=-mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET} --extra-cxxflags=-mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET})
+            endif()
+        else()
+            set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS
+        endif()
+    elseif(VCPKG_TARGET_IS_IOS)
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+            set(LIBVPX_TARGET "armv7-darwin-gcc")
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+            set(LIBVPX_TARGET "arm64-darwin-gcc")
+        else()
+            message(FATAL_ERROR "libvpx does not support architecture ${VCPKG_TARGET_ARCHITECTURE} on iOS")
+        endif()
+    else()
+        set(LIBVPX_TARGET "generic-gnu") # use default target
+    endif()
+
+    if (VCPKG_HOST_IS_BSD)
+        set(MAKE_BINARY "gmake")
+    else()
+        set(MAKE_BINARY "make")
+    endif()
+
+    message(STATUS "Build info. Target: ${LIBVPX_TARGET}; Options: ${OPTIONS}")
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        message(STATUS "Configuring libvpx for Release")
+        file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
+        vcpkg_execute_required_process(
+        COMMAND
+            ${BASH} --noprofile --norc
+            "${SOURCE_PATH}/configure"
+            --target=${LIBVPX_TARGET}
+            ${OPTIONS}
+            ${OPTIONS_RELEASE}
+            ${MAC_OSX_MIN_VERSION_CFLAGS}
+            ${AS_NASM}
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
+        LOGNAME configure-${TARGET_TRIPLET}-rel)
+
+        message(STATUS "Building libvpx for Release")
+        vcpkg_execute_required_process(
+            COMMAND
+                ${BASH} --noprofile --norc -c "${MAKE_BINARY} -j${VCPKG_CONCURRENCY}"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
+            LOGNAME build-${TARGET_TRIPLET}-rel
+        )
+
+        message(STATUS "Installing libvpx for Release")
+        vcpkg_execute_required_process(
+            COMMAND
+                ${BASH} --noprofile --norc -c "${MAKE_BINARY} install"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
+            LOGNAME install-${TARGET_TRIPLET}-rel
+        )
+    endif()
+
+    # --- --- ---
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        message(STATUS "Configuring libvpx for Debug")
+        file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
+        vcpkg_execute_required_process(
+        COMMAND
+            ${BASH} --noprofile --norc
+            "${SOURCE_PATH}/configure"
+            --target=${LIBVPX_TARGET}
+            ${OPTIONS}
+            ${OPTIONS_DEBUG}
+            ${MAC_OSX_MIN_VERSION_CFLAGS}
+            ${AS_NASM}
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+        LOGNAME configure-${TARGET_TRIPLET}-dbg)
+
+        message(STATUS "Building libvpx for Debug")
+        vcpkg_execute_required_process(
+            COMMAND
+                ${BASH} --noprofile --norc -c "${MAKE_BINARY} -j${VCPKG_CONCURRENCY}"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+            LOGNAME build-${TARGET_TRIPLET}-dbg
+        )
+
+        message(STATUS "Installing libvpx for Debug")
+        vcpkg_execute_required_process(
+            COMMAND
+                ${BASH} --noprofile --norc -c "${MAKE_BINARY} install"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+            LOGNAME install-${TARGET_TRIPLET}-dbg
+        )
+
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/libvpx_g.a")
+    endif()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    set(LIBVPX_CONFIG_DEBUG ON)
+else()
+    set(LIBVPX_CONFIG_DEBUG OFF)
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-libvpx-config.cmake.in" "${CURRENT_PACKAGES_DIR}/share/unofficial-libvpx/unofficial-libvpx-config.cmake" @ONLY)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libvpx/unofficial-libvpx-config.cmake.in
+++ b/ports/libvpx/unofficial-libvpx-config.cmake.in
@@ -1,0 +1,49 @@
+if(NOT TARGET unofficial::libvpx::libvpx)
+  # Compute the installation prefix relative to this file.
+  get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+  get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+  get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+
+  # Add library target (note: vpx always has a static build in vcpkg).
+  add_library(unofficial::libvpx::libvpx STATIC IMPORTED)
+
+  # Add interface include directories and link interface languages (applies to all configurations).
+  set_target_properties(unofficial::libvpx::libvpx PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+  )
+  list(APPEND _IMPORT_CHECK_FILES "${_IMPORT_PREFIX}/include/vpx/vpx_codec.h")
+
+  # Add release configuration properties.
+  find_library(_LIBFILE_RELEASE NAMES vpx PATHS "${_IMPORT_PREFIX}/lib/" NO_DEFAULT_PATH)
+  set_property(TARGET unofficial::libvpx::libvpx
+    APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+  set_target_properties(unofficial::libvpx::libvpx PROPERTIES
+    IMPORTED_LOCATION_RELEASE ${_LIBFILE_RELEASE})
+  list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_RELEASE})
+  unset(_LIBFILE_RELEASE CACHE)
+
+  # Add debug configuration properties.
+  if(@LIBVPX_CONFIG_DEBUG@)
+    find_library(_LIBFILE_DEBUG NAMES vpx PATHS "${_IMPORT_PREFIX}/debug/lib/" NO_DEFAULT_PATH)
+    set_property(TARGET unofficial::libvpx::libvpx
+      APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+    set_target_properties(unofficial::libvpx::libvpx PROPERTIES
+      IMPORTED_LOCATION_DEBUG ${_LIBFILE_DEBUG})
+    list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_DEBUG})
+    unset(_LIBFILE_DEBUG CACHE)
+  endif()
+
+  # Check header and library files are present.
+  foreach(file ${_IMPORT_CHECK_FILES} )
+    if(NOT EXISTS "${file}" )
+      message(FATAL_ERROR "unofficial::libvpx::libvpx references the file
+   \"${file}\"
+but this file does not exist.  Possible reasons include:
+* The file was deleted, renamed, or moved to another location.
+* An install or uninstall procedure did not complete successfully.
+")
+    endif()
+  endforeach()
+  unset(_IMPORT_CHECK_FILES)
+endif()

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,0 +1,31 @@
+{
+  "name": "libvpx",
+  "version": "1.16.0",
+  "description": "The reference software implementation for the video coding formats VP8 and VP9.",
+  "homepage": "https://github.com/webmproject/libvpx",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "nasm",
+      "platform": "osx",
+      "version>=": "3.1.0"
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-msbuild",
+      "host": true,
+      "platform": "windows & !mingw"
+    }
+  ],
+  "features": {
+    "highbitdepth": {
+      "description": "use VP9 high bit depth (10/12) profiles"
+    },
+    "realtime": {
+      "description": "enable this option while building for real-time encoding"
+    }
+  }
+}

--- a/ports/libvpx/vpx.pc.in
+++ b/ports/libvpx/vpx.pc.in
@@ -1,0 +1,12 @@
+prefix=@LIBVPX_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: vpx
+Description: WebM Project VPx codec implementation
+Version: @VERSION@
+Requires:
+Conflicts:
+Libs: -L"${libdir}" -lvpx
+Cflags: -I"${includedir}"

--- a/ports/nasm/portfile.cmake
+++ b/ports/nasm/portfile.cmake
@@ -1,0 +1,27 @@
+set(NASM_VERSION "3.01")
+
+set(DIST_URLS
+    "https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/macosx/nasm-${NASM_VERSION}-macosx.zip"
+    "https://www.nasm.dev/pub/nasm/releasebuilds/${NASM_VERSION}/macosx/nasm-${NASM_VERSION}-macosx.zip"
+)
+
+set(SHA512 "1d38da1e8c8c033deea85ecec6b9fcfc4c48503307411316d4dac0a27f6955dcfc9a8f97130312e97c36690ecf3a1263c819163283e45409fe0bfa9dc4a5833d")
+
+vcpkg_download_distfile(
+    ZIP_LOC
+    URLS ${DIST_URLS}
+    FILENAME nasm
+    SHA512 ${SHA512}
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE ${ZIP_LOC}
+    NO_REMOVE_ONE_LEVEL
+)
+
+# Copy tool
+file(COPY ${SOURCE_PATH}/nasm-${NASM_VERSION}/nasm DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
+
+# Usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/nasm/usage
+++ b/ports/nasm/usage
@@ -1,0 +1,3 @@
+nasm can be used with the following:
+
+    find_program(NASM_TOOL nasm REQUIRED)

--- a/ports/nasm/vcpkg.json
+++ b/ports/nasm/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "nasm",
+  "version": "3.1.0",
+  "description": "Assembler and disassembler for the Intel x86 architecture.",
+  "supports": "osx",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -176,8 +176,16 @@
       "baseline": "2018-08-09",
       "port-version": 1
     },
+    "libvpx": {
+      "baseline": "1.16.0",
+      "port-version": 0
+    },
     "msoledbsql": {
       "baseline": "18.1.0",
+      "port-version": 0
+    },
+    "nasm": {
+      "baseline": "3.1.0",
       "port-version": 0
     },
     "nvidia-aftermath": {

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7abae54dc8dceb94742b29f586a36ba68aa7dae0",
+      "version": "1.16.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/n-/nasm.json
+++ b/versions/n-/nasm.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "762cc6297309c316078e895e4885e834a873ec3b",
+      "version": "3.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
libvpx port is a copy of the one in ms vcpkg registry but contains
a method rely on a port to get nasm rather than using brew.
This is only required for macOS x64 and once that platform is retired
both of these ports can be removed.