### PR TITLE
Upgrade imagetools

### DIFF
--- a/ports/carbon-imagetools/portfile.cmake
+++ b/ports/carbon-imagetools/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/imagetools.git
-  REF f9b300d845becc3ec51ce9438b041232d55b66db
+  REF 6b9b1281014bb95c35c2b8ff37f67ed8c0d3f6f1
   HEAD_REF main
 )
 

--- a/ports/carbon-imagetools/vcpkg.json
+++ b/ports/carbon-imagetools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-imagetools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Provides Python bindings and C++ image processing utilities for Carbon projects.",
   "homepage": "https://github.com/carbonengine/imagetools",
   "license": "MIT",
@@ -12,7 +12,7 @@
     },
     {
       "name": "carbon-imageio",
-      "version>=": "2.0.3"
+      "version>=": "2.0.6"
     },
     {
       "name": "carbon-math",
@@ -41,7 +41,7 @@
       "features": [
         "nanovdb-nocuda"
       ],
-      "version>=": "10.0.0"
+      "version>=": "10.0.0#1"
     },
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -85,7 +85,7 @@
       "port-version": 1
     },
     "carbon-imagetools": {
-      "baseline": "2.0.2",
+      "baseline": "2.0.3",
       "port-version": 0
     },
     "carbon-ime": {

--- a/versions/c-/carbon-imagetools.json
+++ b/versions/c-/carbon-imagetools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f63568d3e8561c0c51a9df926d095f8d594b777a",
+      "version": "2.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "68e08839bc3396c8e48649d1d1dc8cd478972dd0",
       "version": "2.0.2",
       "port-version": 0


### PR DESCRIPTION
Upgrade imagetools to v2.0.3, bringing in changes from https://github.com/carbonengine/imagetools/pull/1 