### PR TITLE
Upgrade osx deployment target to 11.0 in triplet files

### DIFF
--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -6,7 +6,7 @@ set(VCPKG_BUILD_TYPE "release")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
-set(VCPKG_OSX_DEPLOYMENT_TARGET 10.14)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
 
 # Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
 # environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
@@ -51,12 +51,6 @@ endif()
 
 if (PORT MATCHES "carbon-pdmprotowrapper")
     set(VCPKG_LIBRARY_LINKAGE static)
-endif ()
-
-if (PORT MATCHES "glslang")
-    # glslang requires a minimum deployment target of 10.15, it conflicts with our current 10.14 target, but it is only consumed by standalone tools to build shaders, not by libraries
-    # that ship with the engine, so we can safely set the deployment target to 10.15 for this port without affecting our supported OS versions for the engine itself
-    set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)
 endif ()
 
 if (PORT MATCHES "meshoptimizer")


### PR DESCRIPTION
Upgrade osx deployment target to 11.0 in triplet files, as this has only been done in the toolchain files:
https://github.com/carbonengine/vcpkg-registry/blame/1d6cf77c4d9913ec47ce8c14d1e4716eec21541f/toolchains/arm64-osx-carbon.cmake#L14