### PR TITLE
Add rule to triplets to build yaml-cpp statically

### DIFF
--- a/triplets/arm64-osx-debug.cmake
+++ b/triplets/arm64-osx-debug.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-internal.cmake
+++ b/triplets/arm64-osx-internal.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-release.cmake
+++ b/triplets/arm64-osx-release.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-osx-trinitydev.cmake
+++ b/triplets/arm64-osx-trinitydev.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-debug.cmake
+++ b/triplets/x64-osx-debug.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-internal.cmake
+++ b/triplets/x64-osx-internal.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-release.cmake
+++ b/triplets/x64-osx-release.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-osx-trinitydev.cmake
+++ b/triplets/x64-osx-trinitydev.cmake
@@ -120,3 +120,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -129,3 +129,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -129,3 +129,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -129,3 +129,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -129,3 +129,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-debug.cmake
+++ b/triplets/x64-windows-debug.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-internal.cmake
+++ b/triplets/x64-windows-internal.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-release.cmake
+++ b/triplets/x64-windows-release.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-trinitydev.cmake
+++ b/triplets/x64-windows-trinitydev.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "libvpx")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()


### PR DESCRIPTION
Add static build rule required for carbon-resources