### PR TITLE
Update `carbon-core` to version `3.0.0`

### DIFF
--- a/ports/carbon-core/vcpkg.json
+++ b/ports/carbon-core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-core",
-  "version": "2.6.0",
+  "version-semver": "3.0.0",
   "description": "Provides generic low-level functionality and cross-platform abstractions for system calls",
   "homepage": "https://github.com/carbonengine/core",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -49,7 +49,7 @@
       "port-version": 0
     },
     "carbon-core": {
-      "baseline": "2.6.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "carbon-d3dinfo": {

--- a/versions/c-/carbon-core.json
+++ b/versions/c-/carbon-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d067a92593fb3918bd35744e4f9eae5072219de6",
+      "version-semver": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "307f546bed79ed6e23a94eae7e736c23d2a2b553",
       "version": "2.6.0",
       "port-version": 0


### PR DESCRIPTION
This PR introduces a port version for the latest major release of `carbon-core`. No other changes to the port are required for this release.