### PR TITLE
Update `carbon-core` to version `3.0.0`

### DIFF
--- a/ports/carbon-core/portfile.cmake
+++ b/ports/carbon-core/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/core.git
-  REF 250df5221bdbb981a46669ac7a7e72ed33e099e0
+  REF 480e628043445a851de0ea9c73ea543cca35a537
   HEAD_REF main
 )
 

--- a/ports/carbon-core/vcpkg.json
+++ b/ports/carbon-core/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-core",
-  "version": "2.6.0",
+  "version-semver": "3.0.0",
   "description": "Provides generic low-level functionality and cross-platform abstractions for system calls",
   "homepage": "https://github.com/carbonengine/core",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -49,7 +49,7 @@
       "port-version": 0
     },
     "carbon-core": {
-      "baseline": "2.6.0",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "carbon-d3dinfo": {

--- a/versions/c-/carbon-core.json
+++ b/versions/c-/carbon-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6d542e78317de6390f04a3280ed7a708f2166c4",
+      "version-semver": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "307f546bed79ed6e23a94eae7e736c23d2a2b553",
       "version": "2.6.0",
       "port-version": 0


### PR DESCRIPTION
This PR introduces a new major version of `carbon-core`. No further port modifications were necessary to accompany this release.