### PR TITLE
Bsdiff static linkage check

### DIFF
--- a/ports/bsdiff-drake127/portfile.cmake
+++ b/ports/bsdiff-drake127/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 set(PATCHES
   patches/ConfigureInstallationRules.patch
 )
@@ -9,8 +11,6 @@ vcpkg_from_git(
   HEAD_REF master
   PATCHES ${PATCHES}
 )
-
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_cmake_configure(
   SOURCE_PATH ${SOURCE_PATH}

--- a/ports/bsdiff-drake127/portfile.cmake
+++ b/ports/bsdiff-drake127/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_git(
   PATCHES ${PATCHES}
 )
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_cmake_configure(
   SOURCE_PATH ${SOURCE_PATH}
 )

--- a/ports/bsdiff-drake127/vcpkg.json
+++ b/ports/bsdiff-drake127/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bsdiff-drake127",
   "version": "4.3.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for building and applying patches to binary files.",
   "dependencies": [
     {

--- a/versions/b-/bsdiff-drake127.json
+++ b/versions/b-/bsdiff-drake127.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "53d8fd8ca4927dfa8e9fa632939d3ac39ce44760",
+      "git-tree": "898011455cb6793ad273d52838ebdbb4aa832fec",
       "version": "4.3.3",
       "port-version": 2
     },

--- a/versions/b-/bsdiff-drake127.json
+++ b/versions/b-/bsdiff-drake127.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53d8fd8ca4927dfa8e9fa632939d3ac39ce44760",
+      "version": "4.3.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "55813e0e11b8b6ddd3c55fccd08ff1e333253f59",
       "version": "4.3.3",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -30,7 +30,7 @@
     },
     "bsdiff-drake127": {
       "baseline": "4.3.3",
-      "port-version": 1
+      "port-version": 2
     },
     "carbon": {
       "baseline": "0.8.0",


### PR DESCRIPTION
Port doesn't support non static linkage so change made here rather than in triplets.
If attempting to use port as shared lib it results in a failed build.