### PR TITLE
Update `carbon-blue` to version `6.0.0`

### DIFF
--- a/ports/carbon-blue/portfile.cmake
+++ b/ports/carbon-blue/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/blue.git
-  REF 245d07a431099232cb6d42c497467d2e7daea097
+  REF 2c7a077d664325f5e66700690683f626dafe06af
   HEAD_REF main
 )
 

--- a/ports/carbon-blue/vcpkg.json
+++ b/ports/carbon-blue/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "carbon-blue",
-  "version": "5.1.2",
-  "port-version": 1,
+  "version-semver": "6.0.0",
   "description": "Central library providing the embedded Python interpreter, game loop, resource-loading and other functions",
   "dependencies": [
     {
@@ -10,7 +9,7 @@
     },
     {
       "name": "carbon-core",
-      "version>=": "2.6.0"
+      "version>=": "3.0.0"
     },
     {
       "name": "carbon-io",
@@ -22,7 +21,7 @@
     },
     {
       "name": "carbon-scheduler",
-      "version>=": "1.4.2"
+      "version>=": "1.4.3"
     },
     {
       "name": "ccp-debug-info",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -41,8 +41,8 @@
       "port-version": 0
     },
     "carbon-blue": {
-      "baseline": "5.1.2",
-      "port-version": 1
+      "baseline": "6.0.0",
+      "port-version": 0
     },
     "carbon-blueexposure": {
       "baseline": "2.1.1",

--- a/versions/c-/carbon-blue.json
+++ b/versions/c-/carbon-blue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2fdfd4aea96654a629fdd623fdc953361d13151",
+      "version-semver": "6.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3b26283dbdd5da5758383a2313b926c367475499",
       "version": "5.1.2",
       "port-version": 1


### PR DESCRIPTION
This PR updates `carbon-blue` to a new major version `6.0.0`. No additional port changes were required to accompany this version increment.