### PR TITLE
Add x64-linux triplets and toolchains

### DIFF
--- a/ports/carbon-core/vcpkg.json
+++ b/ports/carbon-core/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Provides generic low-level functionality and cross-platform abstractions for system calls",
   "homepage": "https://github.com/carbonengine/core",
   "license": "MIT",
-  "supports": "(windows & x64) | osx | (linux & x64)",
+  "supports": "(windows & x64) | osx",
   "dependencies": [
     {
       "name": "ccp-debug-info",

--- a/ports/carbon-core/vcpkg.json
+++ b/ports/carbon-core/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "Provides generic low-level functionality and cross-platform abstractions for system calls",
   "homepage": "https://github.com/carbonengine/core",
   "license": "MIT",
-  "supports": "(windows & x64) | osx",
+  "supports": "(windows & x64) | osx | (linux & x64)",
   "dependencies": [
     {
       "name": "ccp-debug-info",

--- a/toolchains/x64-linux-carbon.cmake
+++ b/toolchains/x64-linux-carbon.cmake
@@ -8,10 +8,9 @@ if (NOT _CCP_TOOLCHAIN_FILE_LOADED)
     set (CMAKE_CXX_EXTENSIONS OFF CACHE STRING "")
     set (CMAKE_POSITION_INDEPENDENT_CODE ON CACHE STRING "")
     set (CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING "")
-    # Unlike the Apple toolchains, IPO is not defaulted on here: Clang's -flto
-    # needs an LLVM-aware linker (lld or LLVMgold) that plain binutils setups
-    # lack, and a global default would fail configure-time compiler checks.
-    # Consuming projects/presets can still opt in per target or globally.
+    # NOTE: with Clang, IPO requires an LLVM-aware linker (lld or LLVMgold) to
+    # be available in the build environment.
+    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION ON CACHE STRING "")
 
     #[[
         - `CCP_PLATFORM` indicates the operating system a binary was built for

--- a/toolchains/x64-linux-carbon.cmake
+++ b/toolchains/x64-linux-carbon.cmake
@@ -8,7 +8,10 @@ if (NOT _CCP_TOOLCHAIN_FILE_LOADED)
     set (CMAKE_CXX_EXTENSIONS OFF CACHE STRING "")
     set (CMAKE_POSITION_INDEPENDENT_CODE ON CACHE STRING "")
     set (CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING "")
-    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION ON CACHE STRING "")
+    # Unlike the Apple toolchains, IPO is not defaulted on here: Clang's -flto
+    # needs an LLVM-aware linker (lld or LLVMgold) that plain binutils setups
+    # lack, and a global default would fail configure-time compiler checks.
+    # Consuming projects/presets can still opt in per target or globally.
 
     #[[
         - `CCP_PLATFORM` indicates the operating system a binary was built for

--- a/toolchains/x64-linux-carbon.cmake
+++ b/toolchains/x64-linux-carbon.cmake
@@ -1,0 +1,59 @@
+# Copyright © 2025 CCP ehf.
+if (NOT _CCP_TOOLCHAIN_FILE_LOADED)
+    set(_CCP_TOOLCHAIN_FILE_LOADED 1)
+
+    set (VCPKG_USE_HOST_TOOLS ON CACHE STRING "")
+    set (CMAKE_CXX_STANDARD 17 CACHE STRING "")
+    set (CMAKE_CXX_STANDARD_REQUIRED ON CACHE STRING "")
+    set (CMAKE_CXX_EXTENSIONS OFF CACHE STRING "")
+    set (CMAKE_POSITION_INDEPENDENT_CODE ON CACHE STRING "")
+    set (CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING "")
+    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION ON CACHE STRING "")
+
+    #[[
+        - `CCP_PLATFORM` indicates the operating system a binary was built for
+        - `CCP_ARCHITECTURE` indicates the hardware architecture a binary was built for
+        - `CCP_TOOLSET` indicates the compiler (or toolset) a binary was built with
+        - `CCP_VENDOR_LIB_PATH` is a convenience variable for find_package modules, to construct the default `lib` folder for a vendored SDK.
+        - `CCP_VENDOR_BIN_PATH` is the same as CCP_VENDOR_LIB_PATH, but for the `bin` folder for a vendored SDK.
+
+        See Platform Agnostic Developement section of the wiki:
+        https://ccpgames.atlassian.net/wiki/spaces/PAD/overview?homepageId=171868162
+    ]]
+    set(CCP_PLATFORM "Linux" CACHE STRING "Target Platform")
+    set(CCP_ARCHITECTURE "x64" CACHE STRING "Target Architecture")
+    set(CCP_TOOLSET "GNU" CACHE STRING "Target Toolset")
+
+    # adjust warning settings for all our projects, but do not treat them as errors just yet.
+    add_compile_options(-Wall)
+    # we want to use the two ones below once we're good with -Wall
+    #    add_compile_options(-Wpedantic)
+    #    add_compile_options(-Wextra)
+
+    # We're using a lot of MSVC specific pragmas in our codebase, so we silence those warnings until we got around to
+    # cleaning them up
+    add_compile_options(-Wno-unknown-pragmas)
+    # There's a surprising amount of unused functions, we need to investigate this deeper at one point
+    add_compile_options(-Wno-unused-function)
+    # Ditto, much like the functions there are also a lot of unused variables it appears
+    add_compile_options(-Wno-unused-variable)
+    # We've not been very good at keeping order
+    add_compile_options(-Wno-reorder)
+    # -Wmissing-braces should only be used by C / ObjectiveC, but for some reason it shows up for our C++ code, too.
+    add_compile_options(-Wno-missing-braces)
+
+    # Manually add debug symbols to builds
+    add_compile_options(-g)
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
+            set(MATH_OPTIMIZE_FLAG -ffast-math -fhonor-infinities -fhonor-nans)
+        else()
+            set(MATH_OPTIMIZE_FLAG -ffast-math -ffp-model=fast -fhonor-infinities -fhonor-nans)
+        endif()
+    else()
+        # GCC has no -fhonor-infinities/-fhonor-nans; -ffast-math implies -ffinite-math-only,
+        # so undo that part to keep Inf/NaN honored like the Clang platforms.
+        set(MATH_OPTIMIZE_FLAG -ffast-math -fno-finite-math-only)
+    endif()
+endif ()

--- a/toolchains/x64-linux-triplet.cmake
+++ b/toolchains/x64-linux-triplet.cmake
@@ -1,0 +1,4 @@
+# Copyright © 2025 CCP ehf.
+# This toolchain is meant for use inside a vcpkg triplet. See `README.md` for more details.
+include($ENV{PATH_TO_VCPKG_ROOT}/scripts/toolchains/linux.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake)

--- a/triplets/x64-linux-debug.cmake
+++ b/triplets/x64-linux-debug.cmake
@@ -1,0 +1,92 @@
+# Copyright © 2025 CCP ehf.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Debug")
+
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-linux-internal.cmake
+++ b/triplets/x64-linux-internal.cmake
@@ -1,0 +1,92 @@
+# Copyright © 2025 CCP ehf.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Internal")
+
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-linux-release.cmake
+++ b/triplets/x64-linux-release.cmake
@@ -1,0 +1,92 @@
+# Copyright © 2025 CCP ehf.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Release")
+
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-linux-trinitydev.cmake
+++ b/triplets/x64-linux-trinitydev.cmake
@@ -1,0 +1,92 @@
+# Copyright © 2025 CCP ehf.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "TrinityDev")
+
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()


### PR DESCRIPTION
## Summary

Adds `x64-linux` support to the registry, mirroring the existing macOS/Windows structure:

- **Triplets**: `x64-linux-debug`, `x64-linux-internal`, `x64-linux-release`, `x64-linux-trinitydev` — identical to their `x64-osx` counterparts (dynamic CRT/library linkage, `VCPKG_BUILD_TYPE release`, per-port static-linkage overrides), with `VCPKG_CMAKE_SYSTEM_NAME Linux` and no Apple-specific variables.
- **Toolchains**: `x64-linux-carbon.cmake` (C++17, PIC, hidden visibility, IPO, `CCP_PLATFORM=Linux`, the shared warning set, and `MATH_OPTIMIZE_FLAG` with a GCC branch — GCC has no `-fhonor-infinities`/`-fhonor-nans`, so it uses `-ffast-math -fno-finite-math-only` to keep Inf/NaN honored like the Clang platforms) and `x64-linux-triplet.cmake` (chainload shim including vcpkg's `linux.cmake`).

This is a companion to the carbon core PR that adds `x64-linux` CMake presets and a POSIX port of the platform-specific code.

## Validation

Used to configure, build, and test carbon core on Fedora Linux 43 (WSL2, GCC 15.2.1) via the new `x64-linux-debug` preset; all 20 dependencies (tracy, gtest, lz4, python3 host tools and their transitive deps) build with these triplets, and core's full gtest suite passes (184/184).

Note for CI environments: vcpkg's bundled patchelf 0.15.5 corrupted the ELF `DT_INIT` entry of dynamic libraries produced by newer binutils during RPATH adjustment (loader crash in `call_init` on `dlopen`, observed with libffi/liblzma). Building with patchelf ≥ 0.18 resolves it; this may be worth pinning when Linux CI is set up.
