### PR TITLE
carbon-core: mark x64-linux as supported

### DIFF
--- a/ports/carbon-core/vcpkg.json
+++ b/ports/carbon-core/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "carbon-core",
   "version-semver": "3.0.0",
+  "port-version": 1,
   "description": "Provides generic low-level functionality and cross-platform abstractions for system calls",
   "homepage": "https://github.com/carbonengine/core",
   "license": "MIT",
-  "supports": "(windows & x64) | osx",
+  "supports": "(windows & x64) | osx | (linux & x64)",
   "dependencies": [
     {
       "name": "ccp-debug-info",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -50,7 +50,7 @@
     },
     "carbon-core": {
       "baseline": "3.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "carbon-d3dinfo": {
       "baseline": "2.0.2",

--- a/versions/c-/carbon-core.json
+++ b/versions/c-/carbon-core.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c032d60da60493be67a32da8dc2e00061dc898a9",
+      "version-semver": "3.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d6d542e78317de6390f04a3280ed7a708f2166c4",
       "version-semver": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
## Summary

Marks `carbon-core` as supported on `x64-linux`, split out of #127 per review feedback to avoid a circular dependency between the toolchain/triplet PR and the core changes.

```
"supports": "(windows & x64) | osx | (linux & x64)"
```

## Dependencies / merge order

1. carbonengine/vcpkg-registry#127 — `x64-linux` triplets and toolchains
2. carbonengine/core#31 — Linux presets and POSIX port of carbon core (validated: full test suite passes on Fedora 43 / GCC 15)
3. this PR (plus a version/REF bump of the port once a core release containing #31 exists)

The umbrella `carbon` port is intentionally left unchanged — most of its components have no Linux port yet.
