### PR TITLE
Force abseil to build statically

### DIFF
--- a/triplets/x64-windows-145-debug.cmake
+++ b/triplets/x64-windows-145-debug.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "yaml-cpp")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "abseil")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-internal.cmake
+++ b/triplets/x64-windows-145-internal.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "yaml-cpp")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "abseil")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-release.cmake
+++ b/triplets/x64-windows-145-release.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "yaml-cpp")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "abseil")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-windows-145-trinitydev.cmake
+++ b/triplets/x64-windows-145-trinitydev.cmake
@@ -133,3 +133,7 @@ endif ()
 if (PORT MATCHES "yaml-cpp")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()
+
+if (PORT MATCHES "abseil")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()


### PR DESCRIPTION
A change in abseil: https://github.com/microsoft/vcpkg/commit/b0fbae8b83a0acb011dca897060f343131293708
Means that it no longer builds statically by default on windows.

This only effects the v145 triplets, as abseil is a dependency of protobuf, and the older v141 compatible version of protobuf relies on an earlier version of abseil which builds statically on windows by default.

Seeing as we do not want to ship an additional dll to users, we should ensure we link against static abseil.