### PR TITLE
Carbon scheduler v1.4.4 update

### DIFF
--- a/ports/carbon-scheduler/portfile.cmake
+++ b/ports/carbon-scheduler/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
-  URL git@github.com:carbonengine/scheduler.git
-  REF 75d6f124d86cd127b410e8350286dcb674882af0
+  URL https://github.com/carbonengine/scheduler.git
+  REF c646f49b12ba2ae784548b242e0cd2051c5550f9
   HEAD_REF main
 )
 

--- a/ports/carbon-scheduler/vcpkg.json
+++ b/ports/carbon-scheduler/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-scheduler",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Provides channels and a scheduler for Greenlet coroutines.",
   "homepage": "https://github.com/carbonengine/scheduler",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "carbon-core",
-      "version>=": "3.0.0"
+      "version>=": "3.1.0"
     },
     {
       "name": "ccp-debug-info",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -141,7 +141,7 @@
       "port-version": 1
     },
     "carbon-scheduler": {
-      "baseline": "1.4.3",
+      "baseline": "1.4.4",
       "port-version": 0
     },
     "carbon-spacemouse": {

--- a/versions/c-/carbon-scheduler.json
+++ b/versions/c-/carbon-scheduler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7eab3af5762a05f35ed02d5862e01a10a25a07f6",
+      "version": "1.4.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "cf3147ce51a39886fbc8996e9f8cdd0a5c14f6f1",
       "version": "1.4.3",
       "port-version": 0


### PR DESCRIPTION
## Summary

This provides a port for the v1.4.4 release of carbon-scheduler, and changes the transport from `ssh` to `https`

## AI assistance disclosure

No AI was involved in this update.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup (no behaviour change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Breaking change (public API or ABI)
- [ ] Other (describe below)

## Linked issue (optional)

PLAT-11484

## What changed

See summary.

## Testing

## Platforms tested

- [ ] Windows
- [ ] macOS
- [] Not applicable

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/carbonengine/.github/blob/main/CONTRIBUTING.md).
- [x] My commits follow the commit-message style described there.
- [x] I've added or updated tests where it made sense.
- [x] I've updated docs / inline API comments for any behaviour change.
- [x] My CLA / ICLA is signed (the bot will let you know if it isn't).
