### PR TITLE
Update resources

### DIFF
--- a/ports/carbon-resources/portfile.cmake
+++ b/ports/carbon-resources/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
         OUT_SOURCE_PATH SOURCE_PATH
         URL https://github.com/carbonengine/resources.git
-        REF 677f05a0605f11ec378553c71874a964023e5010
+        REF 98235597bcf2e4b8d65496974d433eb2b79ab3cc
         HEAD_REF main
 )
 

--- a/ports/carbon-resources/vcpkg.json
+++ b/ports/carbon-resources/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "carbon-resources",
-  "version": "4.3.2",
-  "port-version": 1,
+  "version": "5.0.0",
   "homepage": "https://github.com/carbonengine/resources",
   "license": "MIT",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -137,8 +137,8 @@
       "port-version": 1
     },
     "carbon-resources": {
-      "baseline": "4.3.2",
-      "port-version": 1
+      "baseline": "5.0.0",
+      "port-version": 0
     },
     "carbon-scheduler": {
       "baseline": "1.4.4",

--- a/versions/c-/carbon-resources.json
+++ b/versions/c-/carbon-resources.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "786bf90d9b3708dabc1798055cd48840e55006fe",
+      "version": "5.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "5fbb2e4dd45c38498596d09063d713d0344b5ebc",
       "version": "4.3.2",
       "port-version": 1


### PR DESCRIPTION
## Summary

Add new version of resources to include work done to speed up bundling operations.

## AI assistance disclosure

<!-- Did AI tools generate or significantly assist any part of this PR (code,
tests, commit messages, this description)? If so, briefly say what and how.
Write "None" if not. Be honest: disclosure isn't held against you. What gets a
PR closed is unverified output you can't stand behind, not the use of AI. -->

## Type of change

<!-- Tick all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup (no behaviour change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Breaking change (public API or ABI)
- [x] Other (describe below)

Added new version

## Linked issue (optional)

Changes in version are related to: https://fenriscreations.atlassian.net/browse/PLAT-11754

## What changed

<!-- Short bullets. Aim for the diff-summary you'd want as a reviewer. -->

- Bumped version to 5.0.0

## Testing

vcpkg installed the package using registry point at this branch.
Installed correctly and built CLI states it is on v5.0.0 as expected

## Platforms tested

<!-- Tick what applies. Leave blank if not relevant (e.g. a Python-only or docs change). -->

- [x] Windows
- [ ] macOS
- [ ] Not applicable

## Screenshots / captures

<!-- Only if your change has a visual effect. Drag & drop images here. -->

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/carbonengine/.github/blob/main/CONTRIBUTING.md).
- [x] My commits follow the commit-message style described there.
- [x] I've added or updated tests where it made sense.
- [x] I've updated docs / inline API comments for any behaviour change.
- [x] My CLA / ICLA is signed (the bot will let you know if it isn't).

---

<!--
Heads-up: builds run on our internal CI, not GitHub Actions. On all repos a
maintainer triggers the build after an initial review. Results appear as commit status checks. If you don't see activity
within a few working days, comment on the PR (the maintainers are subscribed), or
@-mention the maintainers team shown in its reviewers.
-->
