### PR TITLE
Update blueexposure to v2.2.0

### DIFF
--- a/ports/carbon-blueexposure/portfile.cmake
+++ b/ports/carbon-blueexposure/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/blueexposure.git
-  REF c855175f5f261a301a12b63c0337e8eb8d92b081
+  REF fc29511269ba22a916cd74f68a88e122eb386d32
   HEAD_REF main
 )
 

--- a/ports/carbon-blueexposure/vcpkg.json
+++ b/ports/carbon-blueexposure/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-blueexposure",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Carbon blue exposure static library",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -45,7 +45,7 @@
       "port-version": 0
     },
     "carbon-blueexposure": {
-      "baseline": "2.1.1",
+      "baseline": "2.2.0",
       "port-version": 0
     },
     "carbon-core": {

--- a/versions/c-/carbon-blueexposure.json
+++ b/versions/c-/carbon-blueexposure.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "310829b583e93b1e6e125845133204df7385cbe5",
+      "version": "2.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ea20bea0b8ed7b4feb63935ff2a757c3e1cd65b3",
       "version": "2.1.1",
       "port-version": 0


### PR DESCRIPTION
## Summary

Upgrade carbon-blueexposure port to v2.2.0, which brings in support for the MSVC v145 compiler