### PR TITLE
Update exefile

### DIFF
--- a/ports/carbon-exefile/portfile.cmake
+++ b/ports/carbon-exefile/portfile.cmake
@@ -14,7 +14,7 @@ endif()
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/exefile.git
-  REF 55f61f3e0e84a8d982749167338237e55e59e3c0
+  REF abeacdaccde0b80a74e61903843756be9e628c6d
   HEAD_REF main
 )
 

--- a/ports/carbon-exefile/vcpkg.json
+++ b/ports/carbon-exefile/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-exefile",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Elements used to build the final exefile executable",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -65,7 +65,7 @@
       "port-version": 1
     },
     "carbon-exefile": {
-      "baseline": "4.1.1",
+      "baseline": "4.2.0",
       "port-version": 0
     },
     "carbon-exefile-interpreter": {

--- a/versions/c-/carbon-exefile.json
+++ b/versions/c-/carbon-exefile.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2dfe6135b90ef757154d55b5cdb5110d09a66745",
+      "version": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d97364a65cdd2fbfa3d514985dd42759d9846338",
       "version": "4.1.1",
       "port-version": 0


### PR DESCRIPTION
## Summary

Upgrade carbon-exefile port to v4.2.0, which brings in support for the MSVC v145 compiler