### PR TITLE
Update proto wrapper

### DIFF
--- a/ports/carbon-pdmprotowrapper/portfile.cmake
+++ b/ports/carbon-pdmprotowrapper/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL git@github.com:carbonengine/pdm-proto-wrapper.git
-  REF d08e220697daa1b17298c257a803da64dcbc64a9
+  REF bb2ca3d9e301179c1b6c417293797f9c3092b1e4
   HEAD_REF master
 )
 

--- a/ports/carbon-pdmprotowrapper/vcpkg.json
+++ b/ports/carbon-pdmprotowrapper/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-pdmprotowrapper",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "C++ library to wrap PDM output in protobuf",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -129,7 +129,7 @@
       "port-version": 0
     },
     "carbon-pdmprotowrapper": {
-      "baseline": "2.0.4",
+      "baseline": "3.0.0",
       "port-version": 0
     },
     "carbon-prometheus": {

--- a/versions/c-/carbon-pdmprotowrapper.json
+++ b/versions/c-/carbon-pdmprotowrapper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a7099d0c22076d8ff60e1f3f03c55fc0e4450ba",
+      "version": "3.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "65b7f36ced95c60a13262736c4756bc277744740",
       "version": "2.0.4",
       "port-version": 0


### PR DESCRIPTION
## Summary

Upgrade carbon-pdmprotowrapper port to v3.0.0, which brings in support for the MSVC v145 compiler