### PR TITLE
Feature/linux support

### DIFF
--- a/toolchains/arm64-linux-carbon.cmake
+++ b/toolchains/arm64-linux-carbon.cmake
@@ -1,0 +1,40 @@
+# Copyright © 2026 CCP ehf.
+
+if (NOT _CCP_TOOLCHAIN_FILE_LOADED)
+    set(_CCP_TOOLCHAIN_FILE_LOADED 1)
+
+    set (VCPKG_USE_HOST_TOOLS ON CACHE STRING "")
+    set (CMAKE_CXX_STANDARD 17 CACHE STRING "")
+    set (CMAKE_CXX_STANDARD_REQUIRED ON CACHE STRING "")
+    set (CMAKE_CXX_EXTENSIONS OFF CACHE STRING "")
+    set (CMAKE_POSITION_INDEPENDENT_CODE ON CACHE STRING "")
+    set (CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING "")
+    set (CMAKE_OBJCXX_VISIBILITY_PRESET hidden CACHE STRING "")
+    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION ON CACHE STRING "")
+
+    #[[
+        - `CCP_PLATFORM` indicates the operating system a binary was built for
+        - `CCP_ARCHITECTURE` indicates the hardware architecture a binary was built for
+        - `CCP_TOOLSET` indicates the compiler (or toolset) a binary was built with
+        - `CCP_VENDOR_LIB_PATH` is a convenience variable for find_package modules, to construct the default `lib` folder for a vendored SDK.
+        - `CCP_VENDOR_BIN_PATH` is the same as CCP_VENDOR_LIB_PATH, but for the `bin` folder for a vendored SDK.
+
+        See Platform Agnostic Developement section of the wiki:
+        https://ccpgames.atlassian.net/wiki/spaces/PAD/overview?homepageId=171868162
+    ]]
+    set(CCP_PLATFORM "Linux" CACHE STRING "Target Platform")
+    set(CCP_ARCHITECTURE "arm64" CACHE STRING "Target Architecture")
+    set(CCP_TOOLSET "GNU" CACHE STRING "Target Toolset")
+
+    # adjust warning settings for all our projects, but do not treat them as errors just yet.
+    add_compile_options(-Wall)
+    # we want to use the two ones below once we're good with -Wall
+    #    add_compile_options(-Wpedantic)
+    #    add_compile_options(-Wextra)
+
+    # Manually add debug symbols to builds
+    add_compile_options(-g)
+
+    # Enable fast, lossy math optimization while disabling optimizations for NaN/+-inf floating points
+    set(MATH_OPTIMIZE_FLAG -ffast-math -fno-finite-math-only)
+endif ()

--- a/toolchains/arm64-linux-triplet.cmake
+++ b/toolchains/arm64-linux-triplet.cmake
@@ -2,4 +2,4 @@
 
 # This toolchain is meant for use inside a vcpkg triplet. See `README.md` for more details.
 include($ENV{PATH_TO_VCPKG_ROOT}/scripts/toolchains/linux.cmake)
-include(x64-linux-carbon.cmake)
+include(arm64-linux-carbon.cmake)

--- a/toolchains/arm64-linux-triplet.cmake
+++ b/toolchains/arm64-linux-triplet.cmake
@@ -1,0 +1,5 @@
+# Copyright © 2026 CCP ehf.
+
+# This toolchain is meant for use inside a vcpkg triplet. See `README.md` for more details.
+include($ENV{PATH_TO_VCPKG_ROOT}/scripts/toolchains/linux.cmake)
+include(x64-linux-carbon.cmake)

--- a/toolchains/x64-linux-carbon.cmake
+++ b/toolchains/x64-linux-carbon.cmake
@@ -1,0 +1,40 @@
+# Copyright © 2026 CCP ehf.
+
+if (NOT _CCP_TOOLCHAIN_FILE_LOADED)
+    set(_CCP_TOOLCHAIN_FILE_LOADED 1)
+
+    set (VCPKG_USE_HOST_TOOLS ON CACHE STRING "")
+    set (CMAKE_CXX_STANDARD 17 CACHE STRING "")
+    set (CMAKE_CXX_STANDARD_REQUIRED ON CACHE STRING "")
+    set (CMAKE_CXX_EXTENSIONS OFF CACHE STRING "")
+    set (CMAKE_POSITION_INDEPENDENT_CODE ON CACHE STRING "")
+    set (CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING "")
+    set (CMAKE_OBJCXX_VISIBILITY_PRESET hidden CACHE STRING "")
+    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION ON CACHE STRING "")
+
+    #[[
+        - `CCP_PLATFORM` indicates the operating system a binary was built for
+        - `CCP_ARCHITECTURE` indicates the hardware architecture a binary was built for
+        - `CCP_TOOLSET` indicates the compiler (or toolset) a binary was built with
+        - `CCP_VENDOR_LIB_PATH` is a convenience variable for find_package modules, to construct the default `lib` folder for a vendored SDK.
+        - `CCP_VENDOR_BIN_PATH` is the same as CCP_VENDOR_LIB_PATH, but for the `bin` folder for a vendored SDK.
+
+        See Platform Agnostic Developement section of the wiki:
+        https://ccpgames.atlassian.net/wiki/spaces/PAD/overview?homepageId=171868162
+    ]]
+    set(CCP_PLATFORM "Linux" CACHE STRING "Target Platform")
+    set(CCP_ARCHITECTURE "x64" CACHE STRING "Target Architecture")
+    set(CCP_TOOLSET "GNU" CACHE STRING "Target Toolset")
+
+    # adjust warning settings for all our projects, but do not treat them as errors just yet.
+    add_compile_options(-Wall)
+    # we want to use the two ones below once we're good with -Wall
+    #    add_compile_options(-Wpedantic)
+    #    add_compile_options(-Wextra)
+
+    # Manually add debug symbols to builds
+    add_compile_options(-g)
+
+    # Enable fast, lossy math optimization while disabling optimizations for NaN/+-inf floating points
+    set(MATH_OPTIMIZE_FLAG -ffast-math -fno-finite-math-only)
+endif ()

--- a/toolchains/x64-linux-triplet.cmake
+++ b/toolchains/x64-linux-triplet.cmake
@@ -1,0 +1,5 @@
+# Copyright © 2026 CCP ehf.
+
+# This toolchain is meant for use inside a vcpkg triplet. See `README.md` for more details.
+include($ENV{PATH_TO_VCPKG_ROOT}/scripts/toolchains/linux.cmake)
+include(x64-linux-carbon.cmake)

--- a/triplets/arm64-linux-debug.cmake
+++ b/triplets/arm64-linux-debug.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "Debug")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/arm64-linux-debug.cmake
+++ b/triplets/arm64-linux-debug.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Debug")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-linux-internal.cmake
+++ b/triplets/arm64-linux-internal.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "Internal")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/arm64-linux-internal.cmake
+++ b/triplets/arm64-linux-internal.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Internal")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-linux-release.cmake
+++ b/triplets/arm64-linux-release.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "Release")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/arm64-linux-release.cmake
+++ b/triplets/arm64-linux-release.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Release")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-linux-trinitydev.cmake
+++ b/triplets/arm64-linux-trinitydev.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "TrinityDev")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/arm64-linux-trinitydev.cmake
+++ b/triplets/arm64-linux-trinitydev.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "TrinityDev")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/arm64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-linux-debug.cmake
+++ b/triplets/x64-linux-debug.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Debug")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-linux-debug.cmake
+++ b/triplets/x64-linux-debug.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "Debug")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-linux-internal.cmake
+++ b/triplets/x64-linux-internal.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "Internal")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-linux-internal.cmake
+++ b/triplets/x64-linux-internal.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Internal")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-linux-release.cmake
+++ b/triplets/x64-linux-release.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "Release")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-linux-release.cmake
+++ b/triplets/x64-linux-release.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "Release")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()

--- a/triplets/x64-linux-trinitydev.cmake
+++ b/triplets/x64-linux-trinitydev.cmake
@@ -14,6 +14,11 @@ set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
 
 set(CARBON_BUILD_TYPE "TrinityDev")
 
+if (PORT MATCHES "carbon-.*")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-triplet.cmake")
+    set(VCPKG_HASH_ADDITIONAL_FILES "${CMAKE_CURRENT_LIST_DIR}/../toolchains/x64-linux-carbon.cmake")
+endif ()
+
 if (PORT MATCHES "libyaml")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif ()

--- a/triplets/x64-linux-trinitydev.cmake
+++ b/triplets/x64-linux-trinitydev.cmake
@@ -1,0 +1,119 @@
+# Copyright © 2026 CCP ehf.
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE "release")
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Changes in vcpkg-tool (https://github.com/microsoft/vcpkg-tool/pull/1931) removed the ability to access the VCPKG_ROOT
+# environment variable from inside the VCPKG build environment while VCPKG_LOAD_VCVARS_ENV is set to ON.
+# For consistency, we have changed this for both windows & macos.
+# More information available here: https://github.com/carbonengine/vcpkg-registry/pull/34
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED PATH_TO_VCPKG_ROOT)
+
+set(CARBON_BUILD_TYPE "TrinityDev")
+
+if (PORT MATCHES "libyaml")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "ccd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "curl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openssl")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "protobuf")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zlib")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libuv")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DBUILD_TESTING=OFF")
+endif()
+
+if (PORT MATCHES "carbon-pdmprotowrapper")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "meshoptimizer")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "tinyfiledialogs")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif ()
+
+if (PORT MATCHES "libjpeg-turbo")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libsquish")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libpng")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "freetype")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "brotli")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "bzip2")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libogg")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvorbis")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "openvdb")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "boost-*")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "imath")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "blosc")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "lz4")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "zstd")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "libvpx")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()
+
+if (PORT MATCHES "yaml-cpp")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif ()


### PR DESCRIPTION
## Summary

This PR introduces arm64 and x64 triplets and toolchains. This acts as a first step for introducing Linux platform support for the carbon game engine.


### Toolchain

The toolchain configures `CMAKE_*` parameters identically to existing Windows and OSX platform toolchains. 

#### Warnings

The toolchain does not attempt to suppress any warnings. There's only a single warning (`-Wno-unused-variable`) we're able to suppress using GCC that we've historically suppressed on other platforms. We're therefore for better or worse forced to start fixing these compilation warnings up. 

#### Compiler ID

The toolchain assumes the toolset or `CMAKE_CXX_COMPILER_ID` to be `GNU`. This information is set at a later point in execution when the `detect_compiler` module is invoked by vcpkg. The assumption made when setting the value of `CCP_TOOLSET` may therefore be incorrect. This also applies to our other toolchains. After some investigation it appears we'd be better served removing this variable entirely and replacing it with `CMAKE_CXX_COMPILER_ID` when needed. This is outside the scope of this PR.


#### Optimization

The Linux toolchains attempt to reflect the optimization being applied by the OSX toolchains. Those toolchains don't set an optimization level directly, but rather expose a set of math optimization flags for interested applications:
- `ffast-math`
- `ffp-model=fast`
- `fhonor-infinities`
- `fhonor-nans`

`ffast-math` enables aggressive, lossy optimizations of floating point numbers. There's a similar, identically named [`ffast-math`](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-ffast-math) flag available in GCC which we set. Similarly to AppleClang, this requires us to explicitly disable floating optimization performed against values assumed to be neither NaN or +-inf using `-fno-finite-math-only`. The `ffast-math`option also sets `fexcess-precission=fast`, I'm mildly confident this correlates to the `ffp-model=fast` option mentioned above. 

## Linked issue (optional)

## Testing

Manual testing was performed by performing a vcpkg installation for `carbon-core` in manifest mode on an x64 windows machine using Ubuntu with WSL. This provides some confidence in the triplets and toolchains introduced to be correctly formatted. 

A minimal program was then compiled using the toolchain.

## AI assistance

None.