### PR TITLE
Upgrade blue to v6.2.0 (MSVC v145 support)

### DIFF
--- a/ports/carbon-blue/portfile.cmake
+++ b/ports/carbon-blue/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
   OUT_SOURCE_PATH SOURCE_PATH
   URL https://github.com/carbonengine/blue.git
-  REF 884a4f98c4fa1a8b317cbed95207c1c2cda1c6b2
+  REF d9d67648e0ffaae397e6399b3e072e05c2380080
   HEAD_REF main
 )
 

--- a/ports/carbon-blue/vcpkg.json
+++ b/ports/carbon-blue/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-blue",
-  "version-semver": "6.1.0",
+  "version-semver": "6.2.0",
   "description": "Central library providing the embedded Python interpreter, game loop, resource-loading and other functions",
   "dependencies": [
     {
@@ -17,11 +17,11 @@
     },
     {
       "name": "carbon-pdmprotowrapper",
-      "version>=": "2.0.4"
+      "version>=": "3.0.0#1"
     },
     {
       "name": "carbon-scheduler",
-      "version>=": "1.4.3"
+      "version>=": "1.4.4"
     },
     {
       "name": "ccp-debug-info",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -41,7 +41,7 @@
       "port-version": 0
     },
     "carbon-blue": {
-      "baseline": "6.1.0",
+      "baseline": "6.2.0",
       "port-version": 0
     },
     "carbon-blueexposure": {

--- a/versions/c-/carbon-blue.json
+++ b/versions/c-/carbon-blue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44e44c0c0f3ac64f86a0685ffc97fbd5f16175c5",
+      "version-semver": "6.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e71bfafa340f06c7c424cc810d45d1b97189b4dc",
       "version-semver": "6.1.0",
       "port-version": 0


### PR DESCRIPTION
## Summary

Upgrade carbon-blue port to v6.2.0, which introduces MSVC v145 support
